### PR TITLE
Fix issue causing onTap and hoverStyle to be ignored

### DIFF
--- a/lib/src/text.dart
+++ b/lib/src/text.dart
@@ -231,10 +231,12 @@ class _CustomTextState extends State<CustomText> {
 
   Text _richText(List<TextElement> elements) {
     return Text.rich(
-      TextSpan(
-        children: elements.isEmpty
-            ? [TextSpan(text: widget.text)]
-            : elements.asMap().entries.map((entry) {
+      // Replacing only inner TextSpan after parsing causes
+      // issue #5, so this outer TextSpan has to be replaced.
+      elements.isEmpty
+          ? TextSpan(text: widget.text)
+          : TextSpan(
+              children: elements.asMap().entries.map((entry) {
                 final index = entry.key;
                 final elm = entry.value;
 
@@ -275,7 +277,7 @@ class _CustomTextState extends State<CustomText> {
                         definition: def,
                       );
               }).toList(),
-      ),
+            ),
       style: widget.style,
       strutStyle: widget.strutStyle,
       textAlign: widget.textAlign,


### PR DESCRIPTION
Fixes #5

A new test for checking this issue has not been added with this fix because it was not possible to reproduce the issue in a widget test. I added a comment instead, which would remind me or someone else of this issue, to prevent the same issue in the future.