### PR TITLE
Big refactor for fixing known issues and improving performance

### DIFF
--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -224,4 +224,220 @@ void main() {
       },
     );
   });
+
+  group('Updating properties', () {
+    testWidgets(
+      'change of tapStyle specified in definition is reflected '
+      'when the widget is rebuilt',
+      (tester) async {
+        var tapStyle = const TextStyle(color: Color(0xFF111111));
+
+        await tester.pumpWidget(
+          StatefulBuilder(builder: (context, setState) {
+            return CustomTextWidget(
+              'aaa bbb@example.com',
+              tapStyleInDef: tapStyle,
+              onTapInDef: (_) {},
+              onButtonPressed: () => setState(() {
+                tapStyle = tapStyle.copyWith(color: const Color(0xFF222222));
+              }),
+            );
+          }),
+        );
+        await tester.pump();
+
+        await tapButton(tester);
+        await tester.pumpAndSettle();
+
+        const email = 'bbb@example.com';
+
+        final span1 = findSpan(email);
+        tapDownSpan(span1);
+        await tester.pump();
+
+        final span2 = findSpan(email);
+        expect(span2?.style?.color, const Color(0xFF222222));
+
+        tapUpSpan(span1);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'change of tapStyle specified in CustomText is reflected '
+      'when the widget is rebuilt',
+      (tester) async {
+        var tapStyle = const TextStyle(color: Color(0xFF111111));
+
+        await tester.pumpWidget(
+          StatefulBuilder(builder: (context, setState) {
+            return CustomTextWidget(
+              'aaa bbb@example.com',
+              tapStyle: tapStyle,
+              onTap: (_, __) {},
+              onButtonPressed: () => setState(() {
+                tapStyle = tapStyle.copyWith(color: const Color(0xFF222222));
+              }),
+            );
+          }),
+        );
+        await tester.pump();
+
+        await tapButton(tester);
+        await tester.pumpAndSettle();
+
+        const email = 'bbb@example.com';
+
+        final span1 = findSpan(email);
+        tapDownSpan(span1);
+        await tester.pump();
+
+        final span2 = findSpan(email);
+        expect(span2?.style?.color, const Color(0xFF222222));
+
+        tapUpSpan(span1);
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
+      'change of tap callback specified in definition is reflected '
+      'when the widget is rebuilt',
+      (tester) async {
+        void onTap2(Type? _, String text) => tappedText = text.toUpperCase();
+
+        var callback = onTap;
+
+        await tester.pumpWidget(
+          StatefulBuilder(builder: (context, setState) {
+            return CustomTextWidget(
+              'aaa bbb@example.com',
+              onTapInDef: (text) => callback(null, text),
+              onButtonPressed: () {
+                setState(() => callback = onTap2);
+              },
+            );
+          }),
+        );
+        await tester.pump();
+
+        await tapButton(tester);
+        await tester.pumpAndSettle();
+
+        const email = 'bbb@example.com';
+
+        final span = findSpan(email);
+        tapDownSpan(span);
+        await tester.pump();
+        tapUpSpan(span);
+        await tester.pump();
+
+        expect(tappedText, equals(email.toUpperCase()));
+      },
+    );
+
+    testWidgets(
+      'change of tap callback specified in CustomText is reflected '
+      'when the widget is rebuilt',
+      (tester) async {
+        void onTap2(Type? _, String text) => tappedText = text.toUpperCase();
+
+        var callback = onTap;
+
+        await tester.pumpWidget(
+          StatefulBuilder(builder: (context, setState) {
+            return CustomTextWidget(
+              'aaa bbb@example.com',
+              onTap: (_, text) => callback(null, text),
+              onButtonPressed: () {
+                setState(() => callback = onTap2);
+              },
+            );
+          }),
+        );
+        await tester.pump();
+
+        await tapButton(tester);
+        await tester.pumpAndSettle();
+
+        const email = 'bbb@example.com';
+
+        final span = findSpan(email);
+        tapDownSpan(span);
+        await tester.pump();
+        tapUpSpan(span);
+        await tester.pump();
+
+        expect(tappedText, equals(email.toUpperCase()));
+      },
+    );
+
+    testWidgets(
+      'text change is reflected to onTap specified in definition '
+      'when the widget is rebuilt',
+      (tester) async {
+        var text = 'aaa bbb@example.com';
+
+        await tester.pumpWidget(
+          StatefulBuilder(builder: (context, setState) {
+            return CustomTextWidget(
+              text,
+              onTapInDef: (text) => onTap(null, text),
+              onButtonPressed: () => setState(() {
+                text = text.toUpperCase();
+              }),
+            );
+          }),
+        );
+        await tester.pump();
+
+        const email = 'BBB@EXAMPLE.COM';
+
+        await tapButton(tester);
+        await tester.pumpAndSettle();
+
+        final span = findSpan(email);
+        tapDownSpan(span);
+        await tester.pump();
+        tapUpSpan(span);
+        await tester.pump();
+
+        expect(tappedText, equals(email));
+      },
+    );
+
+    testWidgets(
+      'text change is reflected to onTap specified in CustomText '
+      'when the widget is rebuilt',
+      (tester) async {
+        var text = 'aaa bbb@example.com';
+
+        await tester.pumpWidget(
+          StatefulBuilder(builder: (context, setState) {
+            return CustomTextWidget(
+              text,
+              onTap: (_, text) => onTap(null, text),
+              onButtonPressed: () => setState(() {
+                text = text.toUpperCase();
+              }),
+            );
+          }),
+        );
+        await tester.pump();
+
+        const email = 'BBB@EXAMPLE.COM';
+
+        await tapButton(tester);
+        await tester.pumpAndSettle();
+
+        final span = findSpan(email);
+        tapDownSpan(span);
+        await tester.pump();
+        tapUpSpan(span);
+        await tester.pump();
+
+        expect(tappedText, equals(email));
+      },
+    );
+  });
 }

--- a/test/text_definition_test.dart
+++ b/test/text_definition_test.dart
@@ -487,7 +487,7 @@ void main() {
 
       final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
       await gesture.addPointer(location: Offset.zero);
-      final center = tester.getCenter(find.byType(RichText));
+      final center = tester.getCenter(find.byType(RichText).first);
 
       await gesture.moveTo(Offset(center.dx / 2, center.dy));
       await tester.pump();
@@ -527,7 +527,7 @@ void main() {
         final gesture =
             await tester.createGesture(kind: PointerDeviceKind.mouse);
         await gesture.addPointer(location: Offset.zero);
-        await gesture.moveTo(tester.getCenter(find.byType(RichText)));
+        await gesture.moveTo(tester.getCenter(find.byType(RichText).first));
         await tester.pump();
 
         final spanA = findSpan('bbb@example.com');

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 bool? isTap;
@@ -21,7 +21,7 @@ void onLongPress(Type? type, String text) {
 
 RichText findRichText() {
   final finder = find.byType(RichText);
-  return finder.evaluate().single.widget as RichText;
+  return finder.evaluate().first.widget as RichText;
 }
 
 List<InlineSpan> getSpans() {
@@ -59,4 +59,9 @@ void tapUpSpan(InlineSpan? span) {
     final onTapUp = (span.recognizer as TapGestureRecognizer?)?.onTapUp;
     onTapUp?.call(TapUpDetails(kind: PointerDeviceKind.touch));
   }
+}
+
+Future<void> tapButton(WidgetTester tester) async {
+  final finder = find.byType(ElevatedButton);
+  await tester.tap(finder);
 }

--- a/test/widgets.dart
+++ b/test/widgets.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 import 'package:custom_text/custom_text.dart';
 
@@ -19,6 +19,7 @@ class CustomTextWidget extends StatelessWidget {
     this.onLongPressInDef,
     this.longPressDuration,
     this.mouseCursor,
+    this.onButtonPressed,
   });
 
   final String text;
@@ -35,35 +36,43 @@ class CustomTextWidget extends StatelessWidget {
   final void Function(String)? onLongPressInDef;
   final Duration? longPressDuration;
   final MouseCursor? mouseCursor;
+  final VoidCallback? onButtonPressed;
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.topLeft,
-      child: CustomText(
-        text,
-        textDirection: TextDirection.ltr,
-        definitions: [
-          const TextDefinition(
-            matcher: UrlMatcher(),
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Column(
+        children: [
+          CustomText(
+            text,
+            definitions: [
+              const TextDefinition(
+                matcher: UrlMatcher(),
+              ),
+              TextDefinition(
+                matcher: const EmailMatcher(),
+                matchStyle: matchStyleInDef,
+                tapStyle: tapStyleInDef,
+                hoverStyle: hoverStyleInDef,
+                onTap: onTapInDef,
+                onLongPress: onLongPressInDef,
+                mouseCursor: mouseCursor,
+              ),
+            ],
+            style: style,
+            matchStyle: matchStyle,
+            tapStyle: tapStyle,
+            hoverStyle: hoverStyle,
+            onTap: onTap,
+            onLongPress: onLongPress,
+            longPressDuration: longPressDuration,
           ),
-          TextDefinition(
-            matcher: const EmailMatcher(),
-            matchStyle: matchStyleInDef,
-            tapStyle: tapStyleInDef,
-            hoverStyle: hoverStyleInDef,
-            onTap: onTapInDef,
-            onLongPress: onLongPressInDef,
-            mouseCursor: mouseCursor,
+          ElevatedButton(
+            child: const Text('Button'),
+            onPressed: onButtonPressed,
           ),
         ],
-        style: style,
-        matchStyle: matchStyle,
-        tapStyle: tapStyle,
-        hoverStyle: hoverStyle,
-        onTap: onTap,
-        onLongPress: onLongPress,
-        longPressDuration: longPressDuration,
       ),
     );
   }


### PR DESCRIPTION
Fixes #13.
Fixes #14.

I took this opportunity to do a major refactoring of two main files (text.dart and text_span_notifier.dart).

- Changed the `CustomTextSpanNotifier` to notify TextSpan itself instead of `tapIndex`/`hoverIndex`.
- Use `ValueListenableBuilder` instead of `FutureBuilder`.
- Replace only a specific child span when it is tapped or hovered instead of recomposing the whole TextSpan.
- Fixed an issue where `TapGestureRecognizer` was not updated (but luckily updated by unnecessary rebuilds).
- Fixed the issue of creating a `CustomTextSpanNotifier` twice when `shouldParse` was true.
- etc.

It is hard to say which of the above fixed which issue, but #13 and #14 were fixed.
I also confirmed that the code after this refactor was free of other old issues filed and fixed previously.

Some tests were also added for checking newer issues and other possible cases.
They include two tests for #13, but it was impossible, for some reason, to make them fail at the version where the issue definitely existed, so they may not be very helpful for finding regressions in the future.
The tests for #14 are working fine.
