### PR TITLE
Add CustomText.selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,29 @@ CustomText(
 )
 ```
 
+### CustomText.selectable
+
+[example8.dart][example8]
+
+![example8](https://user-images.githubusercontent.com/20254485/146570773-41495fc9-9d27-4754-a71e-b2b06e706d4a.gif)
+
+This example is almost the same as example2, but with the `CustomText.selectable` constructor.
+It is based on `SelectableText.rich`, so text can be selected while it is partially decorated/tappable.
+
+```dart
+CustomText.selectable(
+  'URL: https://example.com/\n'
+  'Email: foo@example.com\n'
+  'Tel: +1-012-3456-7890',
+  definitions: [
+    const TextDefinition(matcher: UrlMatcher()),
+    ...,
+  ],
+  matchStyle: const TextStyle(...),
+  ...,
+)
+```
+
 ## Limitations
 
 - The regular expression pattern of `TelMatcher` contains a lookbehind assertion, but
@@ -325,6 +348,7 @@ as is if your app targets Safari.
 [example5]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/example5.dart
 [example6]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/example6.dart
 [example7]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/example7.dart
+[example8]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/example8.dart
 [TelMatcher]: https://pub.dev/documentation/text_parser/latest/text_parser/TelMatcher/TelMatcher.html
 [SelectiveDefinition]: https://pub.dev/documentation/custom_text/latest/custom_text/SelectiveDefinition-class.html
 [SpanDefinition]: https://pub.dev/documentation/custom_text/latest/custom_text/SpanDefinition-class.html

--- a/example/lib/code_view_page.dart
+++ b/example/lib/code_view_page.dart
@@ -53,7 +53,7 @@ class _View extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CustomText(
+    return CustomText.selectable(
       code,
       definitions: const [
         TextDefinition(

--- a/example/lib/examples/example8.dart
+++ b/example/lib/examples/example8.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import 'package:custom_text/custom_text.dart';
+
+class Example8 extends StatelessWidget {
+  const Example8(this.output);
+
+  final void Function(String) output;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomText.selectable(
+      'URL: https://example.com/\n'
+      'Email: foo@example.com\n'
+      'Tel: +1-012-3456-7890',
+      definitions: [
+        const TextDefinition(matcher: UrlMatcher()),
+        const TextDefinition(matcher: EmailMatcher()),
+        TextDefinition(
+          // TODO: Replace with default TelMatcher if Safari supports lookbehind
+          matcher: const TelMatcher(r'(?:\+?[1-9]\d{0,4})?(?:[- ]?\d{1,4})+'),
+          matchStyle: const TextStyle(
+            color: Colors.green,
+            decoration: TextDecoration.underline,
+          ),
+          tapStyle: const TextStyle(color: Colors.orange),
+          onTap: (tel) => output(tel),
+          onLongPress: (tel) => output('[Long press on Tel#] $tel'),
+        ),
+      ],
+      matchStyle: const TextStyle(
+        color: Colors.lightBlue,
+        decoration: TextDecoration.underline,
+      ),
+      tapStyle: const TextStyle(color: Colors.indigo),
+      onTap: (type, text) => output(text),
+      onLongPress: (type, text) => output('[Long press] $text'),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:custom_text_example/examples/example4.dart';
 import 'package:custom_text_example/examples/example5.dart';
 import 'package:custom_text_example/examples/example6.dart';
 import 'package:custom_text_example/examples/example7.dart';
+import 'package:custom_text_example/examples/example8.dart';
 
 void main() => runApp(MyApp());
 
@@ -127,6 +128,18 @@ class MyApp extends StatelessWidget {
                 additionalInfo:
                     'Run the app on desktop to see how this example looks '
                     'and behaves on hover over some strings.',
+              ),
+            ),
+            _ListTile(
+              title: 'CustomText.selectable',
+              builder: (title) => ExamplePage(
+                title,
+                'example8.dart',
+                'A example of selectable CustomText.\n'
+                    'This is almost the same as example2, but different in '
+                    'that this one is based on `SelectableText`, allowing '
+                    'text to be selected.',
+                (outputFunc) => Example8(outputFunc),
               ),
             ),
           ],

--- a/lib/src/text.dart
+++ b/lib/src/text.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:text_parser/text_parser.dart';
@@ -11,13 +13,13 @@ import 'text_span_notifier.dart';
 /// A widget that decorates parts of text and/or enables taps/long-presses
 /// on them according to specified definitions.
 ///
-/// This widget is useful for making strings such as URLs, email addresses
-/// or phone numbers clickable, or for only highlighting some parts of
-/// text with colors and different font settings depending on the types
-/// of string elements.
+/// This widget is useful for making strings in selectable/non-selectable
+/// text such as URLs, email addresses or phone numbers clickable, or for
+/// only highlighting some parts of text with colors and different font
+/// settings depending on the types of string elements.
 class CustomText extends StatefulWidget {
-  /// Creates a widget that decorates parts of text and/or enables clicks
-  /// on them according to specified definitions.
+  /// Creates a text widget that decorates strings in it and/or enables
+  /// clicks on them according to specified definitions.
   const CustomText(
     this.text, {
     Key? key,
@@ -42,7 +44,71 @@ class CustomText extends StatefulWidget {
     this.semanticsLabel,
     this.textWidthBasis,
     this.textHeightBehavior,
-  }) : super(key: key);
+  })  : _isSelectable = false,
+        focusNode = null,
+        showCursor = false,
+        autofocus = false,
+        toolbarOptions = null,
+        minLines = null,
+        cursorWidth = 0.0,
+        cursorHeight = null,
+        cursorRadius = null,
+        cursorColor = null,
+        selectionHeightStyle = null,
+        selectionWidthStyle = null,
+        dragStartBehavior = null,
+        enableInteractiveSelection = false,
+        selectionControls = null,
+        scrollPhysics = null,
+        onSelectionChanged = null,
+        super(key: key);
+
+  /// Creates a selectable text widget that decorates strings in it
+  /// and/or enables clicks on them according to specified definitions.
+  const CustomText.selectable(
+    this.text, {
+    Key? key,
+    required this.definitions,
+    this.parserOptions = const ParserOptions(),
+    this.style,
+    this.matchStyle,
+    this.tapStyle,
+    this.hoverStyle,
+    this.onTap,
+    this.onLongPress,
+    this.longPressDuration,
+    this.preventBlocking = false,
+    this.focusNode,
+    this.strutStyle,
+    this.textAlign,
+    this.textDirection,
+    this.textScaleFactor,
+    this.showCursor = false,
+    this.autofocus = false,
+    this.toolbarOptions,
+    this.minLines,
+    this.maxLines,
+    this.cursorWidth = 2.0,
+    this.cursorHeight,
+    this.cursorRadius,
+    this.cursorColor,
+    this.selectionHeightStyle,
+    this.selectionWidthStyle,
+    this.dragStartBehavior,
+    this.enableInteractiveSelection = true,
+    this.selectionControls,
+    this.scrollPhysics,
+    this.semanticsLabel,
+    this.textHeightBehavior,
+    this.textWidthBasis,
+    this.onSelectionChanged,
+  })  : _isSelectable = true,
+        locale = null,
+        softWrap = null,
+        overflow = null,
+        super(key: key);
+
+  final bool _isSelectable;
 
   /// The text to parse and show.
   final String text;
@@ -117,6 +183,24 @@ class CustomText extends StatefulWidget {
   final String? semanticsLabel;
   final TextWidthBasis? textWidthBasis;
   final TextHeightBehavior? textHeightBehavior;
+
+  // For SelectableText
+  final FocusNode? focusNode;
+  final bool showCursor;
+  final bool autofocus;
+  final ToolbarOptions? toolbarOptions;
+  final int? minLines;
+  final double cursorWidth;
+  final double? cursorHeight;
+  final Radius? cursorRadius;
+  final Color? cursorColor;
+  final ui.BoxHeightStyle? selectionHeightStyle;
+  final ui.BoxWidthStyle? selectionWidthStyle;
+  final DragStartBehavior? dragStartBehavior;
+  final bool enableInteractiveSelection;
+  final TextSelectionControls? selectionControls;
+  final ScrollPhysics? scrollPhysics;
+  final SelectionChangedCallback? onSelectionChanged;
 
   @override
   _CustomTextState createState() => _CustomTextState();
@@ -242,7 +326,8 @@ class _CustomTextState extends State<CustomText> {
   Widget build(BuildContext context) {
     return ValueListenableBuilder<TextSpan>(
       valueListenable: _textSpanNotifier,
-      builder: (context, span, _) => _richText(span),
+      builder: (context, span, _) =>
+          widget._isSelectable ? _richSelectableText(span) : _richText(span),
     );
   }
 
@@ -260,6 +345,38 @@ class _CustomTextState extends State<CustomText> {
       semanticsLabel: widget.semanticsLabel,
       textWidthBasis: widget.textWidthBasis,
       textHeightBehavior: widget.textHeightBehavior,
+    );
+  }
+
+  SelectableText _richSelectableText(TextSpan span) {
+    return SelectableText.rich(
+      span,
+      focusNode: widget.focusNode,
+      style: widget.style,
+      strutStyle: widget.strutStyle,
+      textAlign: widget.textAlign,
+      textDirection: widget.textDirection,
+      textScaleFactor: widget.textScaleFactor,
+      showCursor: widget.showCursor,
+      autofocus: widget.autofocus,
+      toolbarOptions: widget.toolbarOptions,
+      minLines: widget.minLines,
+      maxLines: widget.maxLines,
+      cursorWidth: widget.cursorWidth,
+      cursorHeight: widget.cursorHeight,
+      cursorRadius: widget.cursorRadius,
+      cursorColor: widget.cursorColor,
+      selectionHeightStyle:
+          widget.selectionHeightStyle ?? ui.BoxHeightStyle.tight,
+      selectionWidthStyle: widget.selectionWidthStyle ?? ui.BoxWidthStyle.tight,
+      dragStartBehavior: widget.dragStartBehavior ?? DragStartBehavior.start,
+      enableInteractiveSelection: widget.enableInteractiveSelection,
+      selectionControls: widget.selectionControls,
+      scrollPhysics: widget.scrollPhysics,
+      semanticsLabel: widget.semanticsLabel,
+      textHeightBehavior: widget.textHeightBehavior,
+      textWidthBasis: widget.textWidthBasis,
+      onSelectionChanged: widget.onSelectionChanged,
     );
   }
 }

--- a/lib/src/text_span_notifier.dart
+++ b/lib/src/text_span_notifier.dart
@@ -46,6 +46,7 @@ class CustomTextSpanNotifier extends ValueNotifier<TextSpan> {
   Timer? _timer;
   int? _tapIndex;
   int? _hoverIndex;
+  Offset? _hoverPosition;
 
   @override
   void dispose() {
@@ -118,7 +119,8 @@ class CustomTextSpanNotifier extends ValueNotifier<TextSpan> {
       style: _hoverIndex == index ? hoverStyle : matchStyle,
       mouseCursor: definition.mouseCursor,
       onEnter: hasHoverStyle
-          ? (_) => _updateHoverIndex(
+          ? (event) => _updateHoverIndex(
+                position: event.position,
                 index: index,
                 hovered: true,
                 text: text,
@@ -126,7 +128,8 @@ class CustomTextSpanNotifier extends ValueNotifier<TextSpan> {
               )
           : null,
       onExit: hasHoverStyle
-          ? (_) => _updateHoverIndex(
+          ? (event) => _updateHoverIndex(
+                position: event.position,
                 index: index,
                 hovered: false,
                 text: text,
@@ -171,7 +174,8 @@ class CustomTextSpanNotifier extends ValueNotifier<TextSpan> {
       recognizer: _tapRecognizers[index],
       mouseCursor: definition.mouseCursor,
       onEnter: hasHoverStyle
-          ? (_) => _updateHoverIndex(
+          ? (event) => _updateHoverIndex(
+                position: event.position,
                 index: index,
                 hovered: true,
                 text: text,
@@ -180,7 +184,8 @@ class CustomTextSpanNotifier extends ValueNotifier<TextSpan> {
               )
           : null,
       onExit: hasHoverStyle
-          ? (_) => _updateHoverIndex(
+          ? (event) => _updateHoverIndex(
+                position: event.position,
                 index: index,
                 hovered: false,
                 text: text,
@@ -306,6 +311,7 @@ class CustomTextSpanNotifier extends ValueNotifier<TextSpan> {
   }
 
   void _updateHoverIndex({
+    required Offset position,
     required int index,
     required bool hovered,
     required String text,
@@ -313,8 +319,12 @@ class CustomTextSpanNotifier extends ValueNotifier<TextSpan> {
     String? link,
   }) {
     // Updates only if the span is not being pressed.
-    if (_tapIndex == null) {
+    // The previous and current hovering positions are checked for
+    // preventing repetitive rebuilds that can happen when
+    // CustomText.selectable is used.
+    if (_tapIndex == null && position != _hoverPosition) {
       _hoverIndex = hovered ? index : null;
+      _hoverPosition = hovered ? position : null;
 
       link == null
           ? _updateNonTappableSpan(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.5.1
 repository: https://github.com/kaboc/flutter_custom_text
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.2.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Experimental for the time being because tests for this feature have not been added.
Documentation on the new properties are missing too.

This requires Flutter 2.8 or newer to make `WidgetSpan` available in `SelectableText` on the web.