### PR TITLE
Deprecate `CustomText.selectable` constructor

### DIFF
--- a/example/lib/code_view_page.dart
+++ b/example/lib/code_view_page.dart
@@ -53,6 +53,7 @@ class _CodeViewPageState extends State<CodeViewPage> {
                       controller: _horizontalScrollController,
                       scrollDirection: Axis.horizontal,
                       padding: const EdgeInsets.all(16.0),
+                      // ignore: deprecated_member_use
                       child: CustomText.selectable(
                         snapshot.data!,
                         definitions: dartDefinitions,

--- a/example/lib/common/router.dart
+++ b/example/lib/common/router.dart
@@ -125,6 +125,8 @@ final pages = {
         'This is almost the same as example2, but different in that this '
         'one is based on `SelectableText`, allowing text to be selected.',
     builder: Example8.new,
+    additionalInfo: 'Will be removed in favour of the SelectionArea '
+        'widget in the near future.',
   ),
   9: const ExamplePage(
     page: 9,

--- a/example/lib/examples/example8.dart
+++ b/example/lib/examples/example8.dart
@@ -8,6 +8,7 @@ class Example8 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // ignore: deprecated_member_use
     return CustomText.selectable(
       'URL: https://example.com/\n'
       'Email: foo@example.com\n'

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -21,11 +21,14 @@ class HomePage extends StatelessWidget {
                 title: Text('$i. ${pages[i]!.title}'),
                 subtitle: i < 8
                     ? null
-                    : const Padding(
-                        padding: EdgeInsets.only(left: 18.0),
+                    : Padding(
+                        padding: const EdgeInsets.only(left: 18.0),
                         child: Text(
-                          'Available on v0.6.0 and newer (experimental)',
-                          style: TextStyle(fontSize: 12.0),
+                          [
+                            'Available on v0.6.0-dev.1 and above',
+                            if (i == 8) '\nDeprecated'
+                          ].join(),
+                          style: const TextStyle(fontSize: 12.0),
                         ),
                       ),
                 trailing: const Icon(Icons.chevron_right),

--- a/lib/src/text.dart
+++ b/lib/src/text.dart
@@ -64,6 +64,10 @@ class CustomText extends StatefulWidget {
 
   /// Creates a selectable text widget that decorates strings in it
   /// and/or enables clicks on them according to specified definitions.
+  @Deprecated(
+    'Use SelectionArea on Flutter 3.3 and above, or '
+    '`TextField.readOnly` with `CustomTextEditingController`',
+  )
   const CustomText.selectable(
     this.text, {
     super.key,

--- a/test/widgets.dart
+++ b/test/widgets.dart
@@ -247,6 +247,7 @@ class SelectableCustomTextWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final child = Column(
       children: [
+        // ignore: deprecated_member_use_from_same_package
         CustomText.selectable(
           text,
           definitions: [


### PR DESCRIPTION
Deprecates the `CustomText.selectable` constructor in favour of `SelectionArea` added in Flutter 3.3 and in light of the possibility that `SelectableText` used for the constructor may be removed from the Flutter SDK in the future.

#18

> > SelectionArea doesn't seem to have parameters like `onSelectionChanged` currently.
> 
> TextField with `readOnly: true` and `CustomTextEditingController` looks similarly from the users' point of view. It will provide the functionality equivalent to `CustomText.selectable` in use cases requiring it. Otherwise, `SelectionArea` should be sufficient.
