### PR TITLE
Add `debounceDuration` to CustomTextEditingController

### DIFF
--- a/example/lib/common/router.dart
+++ b/example/lib/common/router.dart
@@ -136,7 +136,7 @@ final pages = {
         'Notice:\n'
         '* SelectiveDefinition and SpanDefinition are not available '
         'for CustomTextEditingController.\n'
-        '* Not suitable for extremely long text.',
+        '* Not suitable for extremely long text, even with debouncing enabled.',
     builder: Example9.new,
     additionalInfo: 'Try editing the text in the box above.\n'
         'As you type, email addresses, URLs and hashtags are decorated, '

--- a/example/lib/examples/example9.dart
+++ b/example/lib/examples/example9.dart
@@ -47,13 +47,38 @@ class _Example9State extends State<Example9> {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      controller: _controller,
-      maxLines: null,
-      style: const TextStyle(height: 1.4),
-      decoration: const InputDecoration(
-        border: OutlineInputBorder(),
-      ),
+    const debounceDuration = Duration(seconds: 1);
+
+    return Column(
+      children: [
+        TextField(
+          controller: _controller,
+          maxLines: null,
+          style: const TextStyle(height: 1.4),
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+          ),
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            const Text(
+              'Debounce\n(experimental)',
+              style: TextStyle(fontSize: 11.0, height: 1.1),
+              textAlign: TextAlign.center,
+            ),
+            Switch(
+              value: _controller.debounceDuration != null,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              onChanged: (on) {
+                setState(() {
+                  _controller.debounceDuration = on ? debounceDuration : null;
+                });
+              },
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/src/transient_elements_builder.dart
+++ b/lib/src/transient_elements_builder.dart
@@ -1,0 +1,252 @@
+import 'package:text_parser/text_parser.dart';
+
+extension on String {
+  String safeSubstring(int start, [int? end]) {
+    final s = start < 0 ? 0 : (start > length ? length : start);
+    return end == null
+        ? substring(s)
+        : substring(s, end < s ? s : (end > length ? length : end));
+  }
+}
+
+extension on List<TextElement> {
+  void updateOffsets() {
+    var offset = 0;
+    asMap().forEach((i, v) {
+      this[i] = _TextElement.from(v).copyWith(offset: offset);
+      offset += v.text.length;
+    });
+  }
+}
+
+class _TextElement extends TextElement {
+  const _TextElement._(
+    super.text,
+    super.groups,
+    super.matcherType,
+    super.offset,
+  );
+
+  factory _TextElement.from(TextElement element) {
+    return _TextElement._(
+      element.text,
+      element.groups,
+      element.matcherType,
+      element.offset,
+    );
+  }
+
+  _TextElement copyWith({String? text, int? offset}) {
+    return _TextElement._(
+      text ?? this.text,
+      groups,
+      matcherType,
+      offset ?? this.offset,
+    );
+  }
+}
+
+class Range {
+  const Range([this.start = -1, this.end = -1]);
+
+  final int start;
+  final int end;
+
+  bool get isInvalid => start < 0 || end < 0;
+}
+
+class BuildResult {
+  const BuildResult({
+    required this.elements,
+    required this.replaceRange,
+    required this.spanRange,
+  });
+
+  final List<TextElement> elements;
+  final Range replaceRange;
+  final Range spanRange;
+}
+
+/// Builds elements to be used transiently while parsing is being debounced.
+class TransientTextElementsBuilder {
+  TransientTextElementsBuilder({
+    required this.oldElements,
+    required this.oldText,
+    required this.newText,
+  });
+
+  final List<TextElement> oldElements;
+  final String oldText;
+  final String newText;
+
+  Range findUpdatedElementsRange() {
+    final elmLen = oldElements.length;
+    var start = -1;
+    var end = -1;
+
+    for (var i = 0; i < elmLen; i++) {
+      final elm = oldElements[i];
+      final from = elm.offset;
+      final to = i == elmLen - 1 ? newText.length : from + elm.text.length;
+      final t = newText.safeSubstring(from, to);
+      if (t != elm.text) {
+        start = i;
+        break;
+      }
+    }
+
+    if (start < 0) {
+      return const Range();
+    }
+
+    var from = newText.length;
+    for (var i = elmLen - 1; i >= start; i--) {
+      final elm = oldElements[i];
+      final to = from;
+      from -= elm.text.length;
+      final t = newText.safeSubstring(i == 0 ? 0 : from, to);
+      if (t != elm.text) {
+        end = i;
+        break;
+      }
+    }
+
+    if (end < 0) {
+      // The change is located in between the text elements.
+      // It should be treated as belonging to the former.
+      start--;
+      end = start;
+    }
+
+    return Range(start, end);
+  }
+
+  BuildResult build({required Range changeRange}) {
+    final oldElmS = _TextElement.from(oldElements[changeRange.start]);
+    final oldElmE = _TextElement.from(oldElements[changeRange.end]);
+
+    // Searches the first element in the change range to find the start
+    // offset of the string not matching the one previously located at the
+    // same offset, and extracts the string before it from the element.
+    int offsetS;
+    var stringA = '';
+    {
+      final string = newText.safeSubstring(
+        oldElmS.offset,
+        oldElmS.offset + oldElmS.text.length,
+      );
+
+      final elmTextLen = string.length;
+      offsetS = oldElmS.offset;
+
+      for (var i = 0; i < elmTextLen; i++) {
+        if (string[i] != oldElmS.text[i]) {
+          offsetS = oldElmS.offset + i;
+          stringA = oldElmS.text.safeSubstring(0, i);
+          break;
+        }
+      }
+    }
+
+    // Searches the last element in the change range to find the end
+    // offset of the string not matching the one previously located at
+    // the same offset, and extracts the string after it from the element.
+    int offsetE;
+    var stringB = '';
+    {
+      var newOffset = newText.length - (oldText.length - oldElmE.offset);
+      var elmTextLen = oldElmE.text.length;
+      if (newOffset < 0) {
+        elmTextLen += newOffset;
+        newOffset = 0;
+      }
+
+      final string = newText.safeSubstring(newOffset, newOffset + elmTextLen);
+      offsetE = newOffset + elmTextLen;
+
+      if (oldElmE != oldElmS) {
+        for (var i = 0; i < elmTextLen; i++) {
+          final t = oldElmE.text;
+          if (string[elmTextLen - i - 1] != t[t.length - i - 1]) {
+            offsetE = newOffset + elmTextLen - i;
+            stringB = t.safeSubstring(t.length - i);
+            break;
+          }
+        }
+      }
+    }
+
+    // Text elements before the change range.
+    final elmsA = changeRange.start == 0
+        ? <TextElement>[]
+        : oldElements.getRange(0, changeRange.start).toList();
+
+    // Text elements after the change range.
+    final elmsB = changeRange.end == oldElements.length - 1
+        ? <TextElement>[]
+        : oldElements
+            .getRange(changeRange.end + 1, oldElements.length)
+            .toList();
+
+    // Appends the changed string to the preceding text.
+    stringA += newText.safeSubstring(offsetS, offsetE);
+
+    var replRangeTo = changeRange.end;
+    var spanRangeTo = changeRange.start;
+
+    // If the start offset of the change range is greater, it means
+    // that the string starting at the offset and possibly also the
+    // strings in some elements after that are a duplicate of the
+    // strings preceding them. Those have to be removed.
+    if (offsetS > offsetE) {
+      var diffLen = offsetS - offsetE;
+
+      if (stringA.isNotEmpty) {
+        final len = stringA.length < diffLen ? stringA.length : diffLen;
+        diffLen -= len;
+        stringA = stringA.substring(0, stringA.length - len);
+      }
+      if (diffLen > 0 && stringB.isNotEmpty) {
+        final len = stringB.length < diffLen ? stringB.length : diffLen;
+        diffLen -= len;
+        stringB = stringB.substring(len);
+      }
+      if (diffLen > 0) {
+        for (var i = 0; i < elmsB.length; i++) {
+          replRangeTo++;
+
+          final elm = _TextElement.from(elmsB[i]);
+          final len = elm.text.length < diffLen ? elm.text.length : diffLen;
+          diffLen -= len;
+          elmsB[i] = elm.copyWith(text: elm.text.substring(len));
+
+          if (diffLen == 0) {
+            elmsB.removeRange(0, len == elm.text.length ? i + 1 : i);
+            if (len < elm.text.length) {
+              spanRangeTo++;
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    if (stringA.isNotEmpty) {
+      spanRangeTo++;
+    }
+    if (stringB.isNotEmpty) {
+      spanRangeTo++;
+    }
+
+    return BuildResult(
+      elements: [
+        ...elmsA,
+        if (stringA.isNotEmpty) oldElmS.copyWith(text: stringA),
+        if (stringB.isNotEmpty) oldElmE.copyWith(text: stringB),
+        ...elmsB,
+      ]..updateOffsets(),
+      replaceRange: Range(changeRange.start, replRangeTo),
+      spanRange: Range(changeRange.start, spanRangeTo),
+    );
+  }
+}

--- a/test/text_editing_controller_test.dart
+++ b/test/text_editing_controller_test.dart
@@ -36,7 +36,7 @@ void main() {
     TextDefinition(matcher: EmailMatcher()),
   ];
 
-  group('CustomTextEditingController', () {
+  group('CustomTextEditingController with debounceDuration', () {
     testWidgets('Initial text is parsed right away', (tester) async {
       final controller = CustomTextEditingController(
         text: 'aaa bbb@example.com',
@@ -72,6 +72,88 @@ void main() {
       expect(controller.elements.first.matcherType, equals(TextMatcher));
       expect(controller.elements.last.text, equals('mple.com'));
       expect(controller.elements.last.matcherType, equals(UrlMatcher));
+    });
+  });
+
+  group('CustomTextEditingController with debounceDuration', () {
+    testWidgets('Initial parsing is not debounced', (tester) async {
+      final controller = CustomTextEditingController(
+        text: 'aaa bbb@example.com',
+        definitions: definitions,
+        debounceDuration: const Duration(milliseconds: 100),
+      );
+      await tester.pumpWidget(
+        _EditorApp(controller: controller, onDispose: controller.dispose),
+      );
+      await tester.pump();
+
+      expect(controller.elements, hasLength(2));
+      expect(controller.elements.first.matcherType, equals(TextMatcher));
+      expect(controller.elements.last.matcherType, equals(EmailMatcher));
+    });
+
+    testWidgets('Parsing is debounced', (tester) async {
+      final controller = CustomTextEditingController(
+        text: 'aaa bbb@example.com',
+        definitions: definitions,
+        debounceDuration: const Duration(milliseconds: 100),
+      );
+      await tester.pumpWidget(
+        _EditorApp(controller: controller, onDispose: controller.dispose),
+      );
+      await tester.pump();
+
+      controller.text = 'aaa bbb@exa mple.com';
+      await tester.pump();
+
+      expect(controller.elements, hasLength(2));
+      expect(controller.elements.first.text, equals('aaa '));
+      expect(controller.elements.first.matcherType, equals(TextMatcher));
+      expect(controller.elements.last.text, equals('bbb@exa mple.com'));
+      expect(controller.elements.last.matcherType, equals(EmailMatcher));
+
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(controller.elements, hasLength(2));
+      expect(controller.elements.first.text, equals('aaa bbb@exa '));
+      expect(controller.elements.first.matcherType, equals(TextMatcher));
+      expect(controller.elements.last.text, equals('mple.com'));
+      expect(controller.elements.last.matcherType, equals(UrlMatcher));
+    });
+
+    testWidgets('debounceDuration can be updated', (tester) async {
+      final controller = CustomTextEditingController(
+        text: 'aaa bbb@example.com',
+        definitions: definitions,
+        debounceDuration: const Duration(milliseconds: 100),
+      );
+      await tester.pumpWidget(
+        _EditorApp(controller: controller, onDispose: controller.dispose),
+      );
+      await tester.pump();
+
+      controller.text = 'aaa bbb@exa mple.com';
+      await tester.pump();
+
+      expect(controller.elements, hasLength(2));
+      expect(controller.elements[0].matcherType, equals(TextMatcher));
+      expect(controller.elements[1].text, equals('bbb@exa mple.com'));
+      expect(controller.elements[1].matcherType, equals(EmailMatcher));
+
+      await tester.pump(const Duration(milliseconds: 300));
+
+      controller
+        ..debounceDuration = null
+        ..text = 'aaa bbb@exa mple.com https://ccc.dd/';
+      await tester.pump();
+
+      expect(controller.elements, hasLength(4));
+      expect(controller.elements[1].text, equals('mple.com'));
+      expect(controller.elements[1].matcherType, equals(UrlMatcher));
+      expect(controller.elements[2].text, equals(' '));
+      expect(controller.elements[2].matcherType, equals(TextMatcher));
+      expect(controller.elements[3].text, equals('https://ccc.dd/'));
+      expect(controller.elements[3].matcherType, equals(UrlMatcher));
     });
   });
 }

--- a/test/transient_build_test.dart
+++ b/test/transient_build_test.dart
@@ -1,0 +1,986 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:custom_text/custom_text_editing_controller.dart';
+import 'package:custom_text/src/text_span_notifier.dart';
+import 'package:custom_text/src/transient_elements_builder.dart';
+
+extension on List<TextElement> {
+  String get text => map((v) => v.text).join();
+}
+
+extension on List<InlineSpan> {
+  String get text => map((v) => v is TextSpan ? v.text : '').join();
+}
+
+void main() {
+  final definitions = [
+    TextDefinition(
+      matcher: const UrlMatcher(),
+      matchStyle: const TextStyle(),
+      tapStyle: const TextStyle(),
+      onTap: (_) {},
+    ),
+    const TextDefinition(
+      matcher: EmailMatcher(),
+      matchStyle: TextStyle(),
+    ),
+    const TextDefinition(
+      matcher: PatternMatcher('#[a-z]+'),
+      matchStyle: TextStyle(),
+      hoverStyle: TextStyle(),
+    ),
+  ];
+  final matchers = definitions.map((def) => def.matcher).toList();
+  final notifier = CustomTextSpanNotifier(text: '', definitions: definitions);
+
+  late List<TextElement> elements;
+
+  tearDownAll(notifier.dispose);
+
+  List<InlineSpan> buildTransientSpan({
+    required List<TextElement> initialElements,
+    required BuildResult elementsBuilderResult,
+  }) {
+    notifier
+      ..elements = initialElements
+      ..buildSpan(
+        style: const TextStyle(),
+        oldElementsLength: 30,
+      )
+      ..elements = elementsBuilderResult.elements
+      ..buildTransientSpan(
+        style: const TextStyle(),
+        replaceRange: elementsBuilderResult.replaceRange,
+        spanRange: elementsBuilderResult.spanRange,
+      );
+
+    return notifier.value.children ?? [];
+  }
+
+  group('Transient text elements and spans', () {
+    const initialText =
+        'abc aaa@bbb.cc abc aaa@bbb.cc \nhttps://bbb.cc abc aaa#hashtag';
+
+    setUpAll(() async {
+      elements = await TextParser(matchers: matchers).parse(initialText);
+    });
+
+    test('Successfully parsed', () {
+      expect(elements, hasLength(8));
+      expect(elements.text, equals(initialText));
+    });
+
+    group('Transient elements and spans have correct text after changes', () {
+      test('Deletions', () {
+        for (var letterLen = 1; letterLen <= initialText.length; letterLen++) {
+          for (var i = 0; i <= initialText.length - letterLen; i++) {
+            final newText = initialText.substring(0, i) +
+                initialText.substring(i + letterLen);
+
+            final builder = TransientTextElementsBuilder(
+              oldElements: elements,
+              oldText: initialText,
+              newText: newText,
+            );
+            final result = builder.build(
+              changeRange: builder.findUpdatedElementsRange(),
+            );
+            expect(result.elements.text, newText);
+
+            final spans = buildTransientSpan(
+              initialElements: elements,
+              elementsBuilderResult: result,
+            );
+            expect(spans.text, equals(newText));
+          }
+        }
+      });
+
+      test('Additions', () {
+        for (var letterLen = 1; letterLen <= 2; letterLen++) {
+          for (var i = 0; i <= initialText.length; i++) {
+            final newText = initialText.substring(0, i) +
+                ('A' * letterLen) +
+                initialText.substring(i);
+
+            final builder = TransientTextElementsBuilder(
+              oldElements: elements,
+              oldText: initialText,
+              newText: newText,
+            );
+            final result = builder.build(
+              changeRange: builder.findUpdatedElementsRange(),
+            );
+            expect(result.elements.text, newText);
+
+            final spans = buildTransientSpan(
+              initialElements: elements,
+              elementsBuilderResult: result,
+            );
+            expect(spans.text, equals(newText));
+          }
+        }
+      });
+
+      test('Replacements', () {
+        for (var fromLen = 1; fromLen <= initialText.length; fromLen++) {
+          for (var replLen = 1; replLen <= fromLen + 1; replLen++) {
+            for (var i = 0; i <= initialText.length - fromLen; i++) {
+              final newText = initialText.substring(0, i) +
+                  ('A' * replLen) +
+                  initialText.substring(i + fromLen);
+
+              final builder = TransientTextElementsBuilder(
+                oldElements: elements,
+                oldText: initialText,
+                newText: newText,
+              );
+              final result = builder.build(
+                changeRange: builder.findUpdatedElementsRange(),
+              );
+              expect(result.elements.text, newText);
+
+              final spans = buildTransientSpan(
+                initialElements: elements,
+                elementsBuilderResult: result,
+              );
+              expect(spans.text, equals(newText));
+            }
+          }
+        }
+      });
+    });
+
+    group('Transient elements and spans are built correctly', () {
+      const initialText =
+          'abcde foo@example.com\nhttps://example.com/ abc #hashtag';
+
+      setUpAll(() async {
+        elements = await TextParser(matchers: matchers).parse(initialText);
+      });
+
+      test('', () {
+        const text = 'a';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(1));
+        expect(result.elements[0].text, equals('a'));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(1));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            '||abcde foo@example.com\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[0].text, equals('||abcde '));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(8));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = '||de foo@example.com\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[0].text, equals('||de '));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(5));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'ab||de foo@example.com\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[0].text, equals('ab||de '));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(7));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'abcde ||foo@example.com\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[0].text, equals('abcde ||'));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(8));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'ab||foo@example.com\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[0].text, equals('ab||'));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(4));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'foo@example.com\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(5));
+        expect(result.elements[0].text, equals('foo@example.com'));
+        expect(result.elements[0].matcherType, equals(EmailMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('\n'));
+        expect(result.elements[1].matcherType, equals(TextMatcher));
+        expect(result.elements[1].offset, equals(15));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(5));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'example.com\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(5));
+        expect(result.elements[0].text, equals('example.com'));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('\n'));
+        expect(result.elements[1].matcherType, equals(TextMatcher));
+        expect(result.elements[1].offset, equals(11));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(5));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abc||example.com\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[0].text, equals('abc||'));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(5));
+        expect(result.elements[2].text, equals('\n'));
+        expect(result.elements[2].matcherType, equals(TextMatcher));
+        expect(result.elements[2].offset, equals(16));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'abcde foo@example.com||\nhttps://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[1].text, equals('foo@example.com||'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(6));
+        expect(result.elements[2].text, equals('\n'));
+        expect(result.elements[2].matcherType, equals(TextMatcher));
+        expect(result.elements[2].offset, equals(23));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'abcde foo@example.com\n||https://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(6));
+        expect(result.elements[2].text, equals('\n||'));
+        expect(result.elements[2].matcherType, equals(TextMatcher));
+        expect(result.elements[2].offset, equals(21));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com||https://example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(6));
+        expect(result.elements[2].text, equals('||'));
+        expect(result.elements[2].matcherType, equals(TextMatcher));
+        expect(result.elements[2].offset, equals(21));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com||example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[2].text, equals('||'));
+        expect(result.elements[2].matcherType, equals(TextMatcher));
+        expect(result.elements[2].offset, equals(21));
+        expect(result.elements[3].text, equals('example.com/'));
+        expect(result.elements[3].matcherType, equals(UrlMatcher));
+        expect(result.elements[3].offset, equals(23));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.comexample.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(5));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(6));
+        expect(result.elements[2].text, equals('example.com/'));
+        expect(result.elements[2].matcherType, equals(UrlMatcher));
+        expect(result.elements[2].offset, equals(21));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(5));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com/ abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(5));
+        expect(result.elements[1].text, equals('foo@example.com'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(6));
+        expect(result.elements[2].text, equals('/'));
+        expect(result.elements[2].matcherType, equals(UrlMatcher));
+        expect(result.elements[2].offset, equals(21));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(5));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'abcde foo@example.com\nhttps://example.com/|| abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[3].text, equals('https://example.com/||'));
+        expect(result.elements[3].matcherType, equals(UrlMatcher));
+        expect(result.elements[3].offset, equals(22));
+        expect(result.elements[4].text, equals(' abc '));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(44));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'abcde foo@example.com\nhttps://example.com/||abc #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[3].text, equals('https://example.com/'));
+        expect(result.elements[3].matcherType, equals(UrlMatcher));
+        expect(result.elements[3].offset, equals(22));
+        expect(result.elements[4].text, equals('||abc '));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(42));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'abcde foo@example.com\nhttps://example.com/ abc ||#hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[4].text, equals(' abc ||'));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(42));
+        expect(result.elements[5].text, equals('#hashtag'));
+        expect(result.elements[5].matcherType, equals(PatternMatcher));
+        expect(result.elements[5].offset, equals(49));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'abcde foo@example.com\nhttps://example.com/ abc||#hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[4].text, equals(' abc||'));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(42));
+        expect(result.elements[5].text, equals('#hashtag'));
+        expect(result.elements[5].matcherType, equals(PatternMatcher));
+        expect(result.elements[5].offset, equals(48));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com\nhttps://example.com/ #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[3].text, equals('https://example.com/'));
+        expect(result.elements[3].matcherType, equals(UrlMatcher));
+        expect(result.elements[3].offset, equals(22));
+        expect(result.elements[4].text, equals(' '));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(42));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com\nhttps://example|| #hashtag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[3].text, equals('https://example||'));
+        expect(result.elements[3].matcherType, equals(UrlMatcher));
+        expect(result.elements[3].offset, equals(22));
+        expect(result.elements[4].text, equals(' '));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(39));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com\nhttps://example.com/ abc #||tag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[5].text, equals('#||tag'));
+        expect(result.elements[5].matcherType, equals(PatternMatcher));
+        expect(result.elements[5].offset, equals(47));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text =
+            'abcde foo@example.com\nhttps://example.com/ abc #hashtag||';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[4].text, equals(' abc '));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(42));
+        expect(result.elements[5].text, equals('#hashtag||'));
+        expect(result.elements[5].matcherType, equals(PatternMatcher));
+        expect(result.elements[5].offset, equals(47));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com\nhttps://example.com/ abc #hash||';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(6));
+        expect(result.elements[5].text, equals('#hash||'));
+        expect(result.elements[5].matcherType, equals(PatternMatcher));
+        expect(result.elements[5].offset, equals(47));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(6));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com\nhttps://example.com/ abc ';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: 'abcde foo@example.com\nhttps://example.com/ abc ',
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(5));
+        expect(result.elements[4].text, equals(' abc '));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(42));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(5));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo@example.com\nhttps://example.com/ abc';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(5));
+        expect(result.elements[4].text, equals(' abc'));
+        expect(result.elements[4].matcherType, equals(TextMatcher));
+        expect(result.elements[4].offset, equals(42));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(5));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abcde foo||tag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(3));
+        expect(result.elements[0].text, equals('abcde '));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('foo||'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(6));
+        expect(result.elements[2].text, equals('tag'));
+        expect(result.elements[2].matcherType, equals(PatternMatcher));
+        expect(result.elements[2].offset, equals(11));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(3));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'abag';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(2));
+        expect(result.elements[0].text, equals('ab'));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+        expect(result.elements[1].text, equals('ag'));
+        expect(result.elements[1].matcherType, equals(PatternMatcher));
+        expect(result.elements[1].offset, equals(2));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(2));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () {
+        const text = 'g';
+        final builder = TransientTextElementsBuilder(
+          oldElements: elements,
+          oldText: initialText,
+          newText: text,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(1));
+        expect(result.elements[0].text, equals('g'));
+        expect(result.elements[0].matcherType, equals(TextMatcher));
+        expect(result.elements[0].offset, equals(0));
+
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(1));
+        expect(spans.text, equals(text));
+      });
+
+      test('', () async {
+        const oldText = 'aaa bbb@ccc.ddd \nhttps://eee.fff/';
+        const newText = 'aaa bbb@ccc.ddd aaa bbb@ccc.ddd \nhttps://eee.fff/';
+        final oldElements = await TextParser(
+          matchers: const [
+            UrlMatcher(),
+            EmailMatcher(),
+            PatternMatcher('#[a-z]+'),
+          ],
+        ).parse(oldText);
+        final builder = TransientTextElementsBuilder(
+          oldElements: oldElements,
+          oldText: oldText,
+          newText: newText,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(4));
+        expect(result.elements[1].text, equals('bbb@ccc.ddd aaa bbb@ccc.ddd'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(4));
+        expect(result.elements[2].text, equals(' \n'));
+        expect(result.elements[2].matcherType, equals(TextMatcher));
+        expect(result.elements[2].offset, equals(31));
+
+        final elements = await TextParser(matchers: matchers).parse(oldText);
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(4));
+        expect(spans.text, equals(newText));
+      });
+
+      test('', () async {
+        const oldText = 'aaa bbb@ccc.ddd aaa bbb@ccc.ddd \nhttps://eee.fff/';
+        const newText = 'aaa bbb@ccc.ddd \nhttps://eee.fff/';
+        final oldElements = await TextParser(
+          matchers: const [
+            UrlMatcher(),
+            EmailMatcher(),
+            PatternMatcher('#[a-z]+'),
+          ],
+        ).parse(oldText);
+        final builder = TransientTextElementsBuilder(
+          oldElements: oldElements,
+          oldText: oldText,
+          newText: newText,
+        );
+        final result = builder.build(
+          changeRange: builder.findUpdatedElementsRange(),
+        );
+        expect(result.elements, hasLength(4));
+        expect(result.elements[1].text, equals('bbb@ccc.ddd'));
+        expect(result.elements[1].matcherType, equals(EmailMatcher));
+        expect(result.elements[1].offset, equals(4));
+        expect(result.elements[2].text, equals(' \n'));
+        expect(result.elements[2].matcherType, equals(TextMatcher));
+        expect(result.elements[2].offset, equals(15));
+
+        final elements = await TextParser(matchers: matchers).parse(oldText);
+        final spans = buildTransientSpan(
+          initialElements: elements,
+          elementsBuilderResult: result,
+        );
+        expect(spans, hasLength(4));
+        expect(spans.text, equals(newText));
+      });
+    });
+  });
+}


### PR DESCRIPTION
With CustomTextEditingController, text is parsed every time it is updated. It becomes more costly as the text becomes longer. If the text is extremely long, it takes time before it is parsed and then the change becomes visible.

`debounceDuration` is for reducing the load. If a duration is given, parsing is started not immediately but only after the duration. If there is some user action before the duration ends, like another text input, a cursor move or a tap/long-press of a text span, the counting of the duration is reset and starts from the beginning.

However, it turned out that just debouncing text parsing was not enough. It appears something else happening (probably on the Flutter SDK side) after text parsing and rebuilding of text spans is time-consuming and slowing down text inputs. So, this feature is marked as experimental for now, and may be removed if its effect is after all not worth the maintenance cost.