### PR TITLE
Fix the issue where changes of some properties in CustomText were not reflected

### DIFF
--- a/lib/src/text.dart
+++ b/lib/src/text.dart
@@ -241,28 +241,28 @@ class _CustomTextState extends State<CustomText> {
     super.didUpdateWidget(oldWidget);
 
     final isMatcherUpdated = _hasNewMatchers(oldWidget);
-    final isDefinitionUpdated =
-        isMatcherUpdated || _hasNewDefinitions(oldWidget);
+    final isDefinitionUpdated = _hasNewDefinitions(oldWidget);
 
-    final shouldParse = isMatcherUpdated ||
+    final needsParse = isMatcherUpdated ||
         widget.text != oldWidget.text ||
         widget.parserOptions != oldWidget.parserOptions ||
         widget.preventBlocking != oldWidget.preventBlocking;
 
-    final shouldUpdateSpan = isDefinitionUpdated ||
+    final needsSpanUpdate = isMatcherUpdated ||
+        isDefinitionUpdated ||
         widget.style != oldWidget.style ||
         widget.matchStyle != oldWidget.matchStyle ||
         widget.tapStyle != oldWidget.tapStyle ||
         widget.hoverStyle != oldWidget.hoverStyle ||
         widget.longPressDuration != oldWidget.longPressDuration;
 
-    if (shouldUpdateSpan) {
+    if (needsSpanUpdate) {
       _textSpanNotifier.updateSettings(_notifierSettings);
     }
 
-    if (shouldParse) {
+    if (needsParse) {
       _parse();
-    } else if (shouldUpdateSpan) {
+    } else if (needsSpanUpdate) {
       _textSpanNotifier.buildSpan(
         style: widget.style,
         oldElementsLength: _textSpanNotifier.elements.length,
@@ -274,26 +274,6 @@ class _CustomTextState extends State<CustomText> {
   void dispose() {
     _textSpanNotifier.dispose();
     super.dispose();
-  }
-
-  Future<void> _parse() async {
-    final elements = await TextParser(
-      matchers: widget.definitions.map((def) => def.matcher).toList(),
-      multiLine: widget.parserOptions.multiLine,
-      caseSensitive: widget.parserOptions.caseSensitive,
-      unicode: widget.parserOptions.unicode,
-      dotAll: widget.parserOptions.dotAll,
-    ).parse(
-      widget.text,
-      useIsolate: widget.preventBlocking,
-    );
-
-    _textSpanNotifier
-      ..elements = elements
-      ..buildSpan(
-        style: widget.style,
-        oldElementsLength: _textSpanNotifier.elements.length,
-      );
   }
 
   bool _hasNewMatchers(CustomText oldWidget) {
@@ -320,6 +300,26 @@ class _CustomTextState extends State<CustomText> {
       }
     }
     return false;
+  }
+
+  Future<void> _parse() async {
+    final elements = await TextParser(
+      matchers: widget.definitions.map((def) => def.matcher).toList(),
+      multiLine: widget.parserOptions.multiLine,
+      caseSensitive: widget.parserOptions.caseSensitive,
+      unicode: widget.parserOptions.unicode,
+      dotAll: widget.parserOptions.dotAll,
+    ).parse(
+      widget.text,
+      useIsolate: widget.preventBlocking,
+    );
+
+    _textSpanNotifier
+      ..elements = elements
+      ..buildSpan(
+        style: widget.style,
+        oldElementsLength: _textSpanNotifier.elements.length,
+      );
   }
 
   @override

--- a/lib/src/text_editing_controller.dart
+++ b/lib/src/text_editing_controller.dart
@@ -181,13 +181,15 @@ class CustomTextEditingController extends TextEditingController {
 
     _textSpanNotifier = CustomTextSpanNotifier(
       text: text,
-      definitions: definitions,
-      matchStyle: matchStyle,
-      tapStyle: tapStyle,
-      hoverStyle: hoverStyle,
-      onTap: onTap,
-      onLongPress: onLongPress,
-      longPressDuration: longPressDuration,
+      settings: NotifierSettings(
+        definitions: definitions,
+        matchStyle: matchStyle,
+        tapStyle: tapStyle,
+        hoverStyle: hoverStyle,
+        onTap: onTap,
+        onLongPress: onLongPress,
+        longPressDuration: longPressDuration,
+      ),
     )..addListener(notifyListeners);
 
     if (text.isNotEmpty) {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:text_parser/text_parser.dart';
+import 'package:custom_text/custom_text.dart';
 
 import 'utils.dart';
 import 'widgets.dart';
@@ -242,6 +242,46 @@ void main() {
   });
 
   group('Updating properties', () {
+    testWidgets('change of matcher is reflected by rebuild', (tester) async {
+      String? value;
+      var definitions = const [
+        TextDefinition(matcher: PatternMatcher('aaa')),
+      ];
+
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (_, setState) {
+            return CustomTextWidget(
+              'aaa bbb',
+              definitions: definitions,
+              onTap: (_, text) => value = text,
+              onButtonPressed: () => setState(() {
+                definitions = const [
+                  TextDefinition(matcher: PatternMatcher('bbb')),
+                ];
+              }),
+            );
+          },
+        ),
+      );
+      await tester.pump();
+
+      final span1 = findSpan('aaa');
+      tapDownSpan(span1);
+      tapUpSpan(span1);
+      await tester.pump();
+      expect(value, equals('aaa'));
+
+      await tapButton(tester);
+      await tester.pumpAndSettle();
+
+      final span2 = findSpan('bbb');
+      tapDownSpan(span2);
+      tapUpSpan(span2);
+      await tester.pump();
+      expect(value, equals('bbb'));
+    });
+
     testWidgets(
       'change of tapStyle specified in definition is reflected '
       'when the widget is rebuilt',

--- a/test/transient_build_test.dart
+++ b/test/transient_build_test.dart
@@ -32,7 +32,10 @@ void main() {
     ),
   ];
   final matchers = definitions.map((def) => def.matcher).toList();
-  final notifier = CustomTextSpanNotifier(text: '', definitions: definitions);
+  final notifier = CustomTextSpanNotifier(
+    text: '',
+    settings: NotifierSettings(definitions: definitions),
+  );
 
   late List<TextElement> elements;
 

--- a/test/widgets.dart
+++ b/test/widgets.dart
@@ -7,6 +7,7 @@ import 'package:custom_text/custom_text.dart';
 class CustomTextWidget extends StatelessWidget {
   const CustomTextWidget(
     this.text, {
+    this.definitions,
     this.style,
     this.matchStyle,
     this.tapStyle,
@@ -24,6 +25,7 @@ class CustomTextWidget extends StatelessWidget {
   });
 
   final String text;
+  final List<TextDefinition>? definitions;
   final TextStyle? style;
   final TextStyle? matchStyle;
   final TextStyle? tapStyle;
@@ -47,20 +49,21 @@ class CustomTextWidget extends StatelessWidget {
         children: [
           CustomText(
             text,
-            definitions: [
-              const TextDefinition(
-                matcher: UrlMatcher(),
-              ),
-              TextDefinition(
-                matcher: const EmailMatcher(),
-                matchStyle: matchStyleInDef,
-                tapStyle: tapStyleInDef,
-                hoverStyle: hoverStyleInDef,
-                onTap: onTapInDef,
-                onLongPress: onLongPressInDef,
-                mouseCursor: mouseCursor,
-              ),
-            ],
+            definitions: definitions ??
+                [
+                  const TextDefinition(
+                    matcher: UrlMatcher(),
+                  ),
+                  TextDefinition(
+                    matcher: const EmailMatcher(),
+                    matchStyle: matchStyleInDef,
+                    tapStyle: tapStyleInDef,
+                    hoverStyle: hoverStyleInDef,
+                    onTap: onTapInDef,
+                    onLongPress: onLongPressInDef,
+                    mouseCursor: mouseCursor,
+                  ),
+                ],
             style: style,
             matchStyle: matchStyle,
             tapStyle: tapStyle,


### PR DESCRIPTION
Fixes #21.

This contains a change to eliminate replacements of `TextSpanNotifier`. It was necessary to fix the issue but I think it is also a nice improvement; text.dart is now much easier to comprehend.