### PR TITLE
Make text invisible during initial parsing

### DIFF
--- a/lib/src/definition_base.dart
+++ b/lib/src/definition_base.dart
@@ -73,4 +73,7 @@ abstract class Definition {
         hoverStyle,
         mouseCursor,
       );
+
+  /// Whether the definition is TextDefinition.
+  bool get isTextDefinition => shownText == null && builder == null;
 }

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -68,6 +68,13 @@ class SelectiveDefinition extends Definition {
   /// object passed to [onTap], [onLongPress] and [onGesture].
   ///
   /// {@macro customText.definition.mouseCursor}
+  ///
+  /// When this definition type is used, the text selected by
+  /// [shownText] is not shown until parsing completes and reveals
+  /// which parts in the original text need to be replaced with
+  /// the selected text, so that the raw text is not shown as is
+  /// while waiting. Exceptionally, this behaviour is not applied
+  /// if [CustomText.preventBlocking] is enabled.
   const SelectiveDefinition({
     required super.matcher,
     required ShownTextSelector super.shownText,
@@ -93,6 +100,13 @@ class SpanDefinition extends Definition {
   /// parentheses within the match pattern. Use the function to return
   /// an object of [InlineSpan] or its subtype (e.g. [WidgetSpan]) to
   /// display it instead of the matched string.
+  ///
+  /// When this definition type is used, the [InlineSpan] created by
+  /// the [builder] callback is not shown until parsing completes and
+  /// reveals which parts in the original text need to be replaced
+  /// with the span, so that the raw text is not shown as is while
+  /// waiting. Exceptionally, this behaviour is not applied if
+  /// [CustomText.preventBlocking] is enabled.
   const SpanDefinition({
     required super.matcher,
     required SpanBuilder super.builder,

--- a/lib/src/text.dart
+++ b/lib/src/text.dart
@@ -201,13 +201,17 @@ class _CustomTextState extends State<CustomText> {
   NotifierSettings _createNotifierSettings() {
     return NotifierSettings(
       definitions: widget.definitions,
-      // Keeps text transparent until parsing completes to prevent
-      // the strings that should not be shown (e.g. symbols for
-      // LinkMatcher `[]()`) from being visible for an instant.
-      // Exceptionally, text is not made invisible if `preventBlocking`
-      // is enabled because it means the user has opted in to quickly
-      // show the raw text without waiting.
-      style: widget.preventBlocking
+      // Keeps text transparent during initial parsing to prevent the
+      // strings that should not be shown (e.g. symbols for LinkMatcher
+      // `[]()`) from being visible for an instant.
+      // Exceptionally, text is not made invisible in the following cases:
+      //
+      // * When `preventBlocking` is enabled, which means the user has
+      //   chosen to show the raw text without it blocked by parsing.
+      // * When `definitions` contains only TextDefinition, in which case
+      //   the shown text remains unchanged before and after parsing.
+      style: widget.preventBlocking ||
+              widget.definitions.every((def) => def.isTextDefinition)
           ? widget.style
           : widget.style?.copyWith(color: const Color(0x00000000)) ??
               const TextStyle(color: Color(0x00000000)),

--- a/lib/src/text.dart
+++ b/lib/src/text.dart
@@ -201,7 +201,16 @@ class _CustomTextState extends State<CustomText> {
   NotifierSettings _createNotifierSettings() {
     return NotifierSettings(
       definitions: widget.definitions,
-      style: widget.style,
+      // Keeps text transparent until parsing completes to prevent
+      // the strings that should not be shown (e.g. symbols for
+      // LinkMatcher `[]()`) from being visible for an instant.
+      // Exceptionally, text is not made invisible if `preventBlocking`
+      // is enabled because it means the user has opted in to quickly
+      // show the raw text without waiting.
+      style: widget.preventBlocking
+          ? widget.style
+          : widget.style?.copyWith(color: const Color(0x00000000)) ??
+              const TextStyle(color: Color(0x00000000)),
       matchStyle: widget.matchStyle,
       tapStyle: widget.tapStyle,
       hoverStyle: widget.hoverStyle,

--- a/test/widget_tests/widgets.dart
+++ b/test/widget_tests/widgets.dart
@@ -23,6 +23,7 @@ class CustomTextWidget extends StatelessWidget {
     this.onGestureInDef,
     this.longPressDuration,
     this.mouseCursor,
+    this.preventBlocking = false,
     this.onButtonPressed,
   });
 
@@ -44,6 +45,7 @@ class CustomTextWidget extends StatelessWidget {
   final GestureCallback? onGestureInDef;
   final Duration? longPressDuration;
   final MouseCursor? mouseCursor;
+  final bool preventBlocking;
   final VoidCallback? onButtonPressed;
 
   @override
@@ -79,6 +81,7 @@ class CustomTextWidget extends StatelessWidget {
             onLongPress: onLongPress,
             onGesture: onGesture,
             longPressDuration: longPressDuration,
+            preventBlocking: preventBlocking,
           ),
           ElevatedButton(
             onPressed: onButtonPressed,


### PR DESCRIPTION
The raw text containing characters that are not supposed to be shown (e.g. symbols for LinkMatcher) are visible for an instant while the text is parsed and spans are built. This PR resolves the issue by making text transparent until it becomes ready.

- Text is invisible only during the initial parsing.
- Text is transparent but exists, so the space for text is reserved early (although it may not be the final size as it is not known yet). It prevents the space from changing a lot when parsing completes and thus avoids affecting the position of widgets around the text.
- Exceptionally, text is not made invisible in the following cases:
    - `preventBlocking` is set to `true`
        - Because it is an option to avoid blocking of the UI including the text.
    - `definitions` contains only `TextDefinition`
        - Because the shown text is the same as the original text in TextDefinition, while it is different in `SelectiveDefinition` and `SpanDefinition`.

`preventBlocking` should be used if parsing takes so long that users can think the transparent text is ugly. So there should be no problem in normal usage.
