### PR TITLE
Deprecate `textScaleFactor`

### DIFF
--- a/lib/src/text.dart
+++ b/lib/src/text.dart
@@ -11,6 +11,17 @@ import 'text_span/data.dart';
 import 'text_span/span_utils.dart';
 import 'text_span/text_span_notifier.dart';
 
+const _kTextScaleFactorDeprecation =
+    'Use `MediaQuery` instead or ignore this warning depending on the '
+    'Flutter SDK version you are currently using, until `textScaler` '
+    'becomes available at a newer version of custom_text. This was '
+    'deprecated at custom_text 1.3.0.\n'
+    '* < Flutter 3.16: Ignore this warning for now.\n'
+    '* >= Flutter 3.16: Wrap `CustomText` or `CustomText.spans` with '
+    '`MediaQuery`, `MediaQuery.withNoTextScaling` or '
+    '`MediaQuery.withClampedTextScaling` to override the text scaling '
+    'strategy.';
+
 /// A text widget that decorates partial strings in it, and enables tap,
 /// long-press and/or hover gestures based on flexible definitions.
 ///
@@ -65,7 +76,7 @@ class CustomText extends StatefulWidget {
     this.locale,
     this.softWrap,
     this.overflow,
-    this.textScaleFactor,
+    @Deprecated(_kTextScaleFactorDeprecation) this.textScaleFactor,
     this.maxLines,
     this.semanticsLabel,
     this.textWidthBasis,
@@ -153,7 +164,7 @@ class CustomText extends StatefulWidget {
     this.locale,
     this.softWrap,
     this.overflow,
-    this.textScaleFactor,
+    @Deprecated(_kTextScaleFactorDeprecation) this.textScaleFactor,
     this.maxLines,
     this.semanticsLabel,
     this.textWidthBasis,
@@ -286,6 +297,7 @@ class CustomText extends StatefulWidget {
   final Locale? locale;
   final bool? softWrap;
   final TextOverflow? overflow;
+  @Deprecated(_kTextScaleFactorDeprecation)
   final double? textScaleFactor;
   final int? maxLines;
   final String? semanticsLabel;
@@ -474,6 +486,7 @@ class _CustomTextState extends State<CustomText> {
         locale: widget.locale,
         softWrap: widget.softWrap,
         overflow: widget.overflow,
+        // ignore: deprecated_member_use_from_same_package
         textScaleFactor: widget.textScaleFactor,
         maxLines: widget.maxLines,
         semanticsLabel: widget.semanticsLabel,


### PR DESCRIPTION
#35

This change deprecates `textScaleFactor` without providing an alternative. It is to avoid the necessity to raise the minimum Flutter SDK version and the major version of this package only for this reason. Users using a Flutter SDK version older than 3.17 can add an ignore comment to suppress the warning for now.

`textScaler` will be added to the `CustomText` widget at a future major version, probably around the release of the next Flutter stable version.
