### PR TITLE
Add `preBuilder` to CustomText

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,41 @@ CustomText.spans(
 )
 ```
 
+### ⭐ <b>CustomText with preBuilder</b>
+
+pre_builder.dart ([Code][example_pre_builder] / [Demo][demo_pre_builder])
+
+![Image - CustomText with preBuilder](https://github.com/kaboc/flutter_custom_text/assets/20254485/3066d802-b444-4ea7-9206-54941e572ac4)
+
+An example of [preBuilder] that allows to apply decorations and then additionally
+apply another decorations and gesture callbacks to them.
+
+It has similar use cases to [CustomText.spans], but is more helpful when it is
+difficult to compose complex spans manually.
+
+The example below makes "KISS" and "Keep It Simple, Stupid!" bold, and then
+applies a colour to capital letters contained in them.
+
+```dart
+CustomText(
+  'KISS is an acronym for "Keep It Simple, Stupid!".',
+  definitions: const [
+    TextDefinition(
+      matcher: PatternMatcher('[A-Z]'),
+      matchStyle: TextStyle(color: Colors.red),
+    ),
+  ],
+  preBuilder: CustomSpanBuilder(
+    definitions: [
+      const TextDefinition(
+        matcher: PatternMatcher('KISS|Keep.+Stupid!'),
+        matchStyle: TextStyle(fontWeight: FontWeight.bold),
+      ),
+    ],
+  ),
+)
+```
+
 ### ⭐ <b>CustomTextEditingController</b>
 
 text_editing_controller.dart ([Code][example_text_editing_controller] / [Demo][demo_text_editing_controller])
@@ -572,6 +607,7 @@ CustomText(
 [example_hover_style]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/hover_style.dart
 [example_on_gesture]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/on_gesture.dart
 [example_spans_constructor]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/spans_constructor.dart
+[example_pre_builder]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/pre_builder.dart
 [example_text_editing_controller]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/text_editing_controller.dart
 [example_external_parser]: https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/external_parser.dart
 [demo_simple]: https://kaboc.github.io/flutter_custom_text/#/simple
@@ -584,9 +620,11 @@ CustomText(
 [demo_hover_style]: https://kaboc.github.io/flutter_custom_text/#/hover-style
 [demo_on_gesture]: https://kaboc.github.io/flutter_custom_text/#/on-gesture
 [demo_spans_constructor]: https://kaboc.github.io/flutter_custom_text/#/spans-constructor
+[demo_pre_builder]: https://kaboc.github.io/flutter_custom_text/#/pre-builder
 [demo_text_editing_controller]: https://kaboc.github.io/flutter_custom_text/#/text-editing-controller
 [demo_external_parser]: https://kaboc.github.io/flutter_custom_text/#/external-parser
 [CustomText.spans]: https://pub.dev/documentation/custom_text/latest/custom_text/CustomText/CustomText.spans.html
+[preBuilder]: https://pub.dev/documentation/custom_text/latest/custom_text/CustomText/preBuilder.html
 [CustomTextEditingController]: https://pub.dev/documentation/custom_text/latest/custom_text/CustomTextEditingController-class.html
 [TextMatcher]: https://pub.dev/documentation/text_parser/latest/text_parser/TextMatcher-class.html
 [UrlMatcher]: https://pub.dev/documentation/text_parser/latest/text_parser/UrlMatcher-class.html

--- a/example/README.md
+++ b/example/README.md
@@ -12,6 +12,7 @@ A demo app showing all the following examples.
 - [Changing mouse cursor and text style on hover](https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/hover_style.dart)
 - [Event positions and onGesture](https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/on_gesture.dart)
 - [CustomText.spans](https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/spans_constructor.dart)
+- [CustomText with preBuilder](https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/pre_builder.dart)
 - [CustomTextEditingController](https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/text_editing_controller.dart)
 - [Using an external parser](https://github.com/kaboc/flutter_custom_text/blob/main/example/lib/examples/src/external_parser.dart)
 

--- a/example/lib/common/router.dart
+++ b/example/lib/common/router.dart
@@ -12,6 +12,7 @@ import 'package:custom_text_example/examples/src/external_parser.dart';
 import 'package:custom_text_example/examples/src/hover_style.dart';
 import 'package:custom_text_example/examples/src/on_gesture.dart';
 import 'package:custom_text_example/examples/src/overwriting_pattern.dart';
+import 'package:custom_text_example/examples/src/pre_builder.dart';
 import 'package:custom_text_example/examples/src/real_hyperlinks.dart';
 import 'package:custom_text_example/examples/src/selective_definition.dart';
 import 'package:custom_text_example/examples/src/simple.dart';
@@ -174,6 +175,16 @@ final pages = [
     additionalInfo: 'This example applies hoverStyle, tapStyle and onTap '
         'to the range containing multiple styled InlineSpans including '
         'a WidgetSpan.',
+  ),
+  ExamplePage(
+    pathString: 'pre-builder',
+    title: 'CustomText with preBuilder',
+    description: '`preBuilder` allows to apply decorations and then '
+        'additionally apply more decorations and enable gestures.\n'
+        'It has similar use cases to `CustomText.spans`, but is more '
+        'helpful when it is not easy to compose complex spans manually.',
+    builder: (_) => const PreBuilderExample(),
+    hasOutput: false,
   ),
   ExamplePage(
     pathString: 'text-editing-controller',

--- a/example/lib/examples/src/pre_builder.dart
+++ b/example/lib/examples/src/pre_builder.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:custom_text/custom_text.dart';
+
+class PreBuilderExample extends StatelessWidget {
+  const PreBuilderExample();
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomText(
+      'KISS is an acronym for "Keep It Simple, Stupid!".',
+      definitions: const [
+        TextDefinition(
+          matcher: PatternMatcher('[A-Z]'),
+          matchStyle: TextStyle(color: Colors.red),
+        ),
+      ],
+      preBuilder: CustomSpanBuilder(
+        definitions: [
+          const TextDefinition(
+            matcher: PatternMatcher('KISS|Keep.+Stupid!'),
+            matchStyle: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/custom_text.dart
+++ b/lib/custom_text.dart
@@ -1,5 +1,6 @@
 export 'package:text_parser/text_parser.dart';
 
+export 'src/builder.dart';
 export 'src/definition_base.dart';
 export 'src/definitions.dart';
 export 'src/gesture_details.dart';

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/painting.dart';
+import 'package:meta/meta.dart';
+
+import 'package:text_parser/text_parser.dart';
+
+import 'definition_base.dart';
+import 'parser_options.dart';
+import 'text.dart';
+import 'utils.dart';
+import 'text_span/data.dart';
+import 'text_span/spans_builder.dart';
+
+/// A class that builds a [TextSpan] based on [definitions].
+///
+/// {@template customText.CustomSpanBuilder}
+/// This builder is basically used with [CustomText], although it is
+/// also possible to use it independently. The example below makes
+/// "KISS" and "Keep It Simple, Stupid!" bold, and additionally
+/// applies a colour to capital letters contained in them.
+///
+/// ```dart
+/// CustomText(
+///   'KISS is an acronym for "Keep It Simple, Stupid!".',
+///   preBuilder: CustomSpanBuilder(
+///     definitions: [
+///       const TextDefinition(
+///         matcher: PatternMatcher('KISS|Keep.+Stupid!'),
+///         matchStyle: TextStyle(fontWeight: FontWeight.bold),
+///       ),
+///     ],
+///   ),
+///   definitions: const [
+///     TextDefinition(
+///       matcher: PatternMatcher('[A-Z]'),
+///       matchStyle: TextStyle(color: Colors.red),
+///     ),
+///   ],
+/// )
+/// ```
+///
+/// The usage is similar to [CustomText]. However, there is an important
+/// difference that gesture actions specified in definitions are
+/// deactivated in this builder. Exceptionally, `mouseCursor` is not
+/// deactivated if the builder is used independently without being used
+/// with `CustomText`.
+/// {@endtemplate}
+class CustomSpanBuilder {
+  /// Creates a [CustomSpanBuilder] that builds a [TextSpan] based
+  /// on [definitions].
+  ///
+  /// {@macro customText.CustomSpanBuilder}
+  CustomSpanBuilder({
+    required this.definitions,
+    this.parserOptions = const ParserOptions(),
+    this.style,
+    this.matchStyle,
+    this.preventBlocking = false,
+  }) : _spansBuilder = SpansBuilder(
+          settings: SpansBuilderSettings(
+            definitions: definitions,
+            style: style,
+            matchStyle: matchStyle,
+          ),
+        );
+
+  /// Definitions that specify rules for parsing, appearance and actions.
+  ///
+  /// Note that gesture actions are deactivated. Exceptionally,
+  /// `mouseCursor` is not deactivated if the builder is used
+  /// independently without being used with [CustomText].
+  final List<Definition> definitions;
+
+  /// The options for [RegExp] that configure how regular expressions
+  /// are treated.
+  final ParserOptions parserOptions;
+
+  /// The text style for strings that did not match any match patterns.
+  final TextStyle? style;
+
+  /// The default text style for matched strings.
+  final TextStyle? matchStyle;
+
+  /// Whether to use an isolate for parsing to avoid blocking of the UI.
+  ///
+  /// When [CustomSpanBuilder] is used with [CustomText], it is
+  /// recommended that this flag is omitted or set to `false`.
+  /// Setting it otherwise adds an overhead to the parsing that occurs
+  /// in the builder before another parsing occurs in `CustomText`.
+  final bool preventBlocking;
+
+  final SpansBuilder _spansBuilder;
+
+  String _text = '';
+  TextSpan _span = const TextSpan();
+
+  @internal
+  // ignore: public_member_api_docs
+  String spanText() {
+    return _span.toPlainText();
+  }
+
+  bool _parsed = false;
+  bool _built = false;
+
+  @visibleForTesting
+  // ignore: public_member_api_docs
+  TextSpan get span => _span;
+
+  /// Whether the most recent call to [build] caused text parsing.
+  @visibleForTesting
+  bool get parsed => _parsed;
+
+  /// Whether the most recent call to [build] caused a build of spans.
+  @internal
+  bool get built => _built;
+
+  /// Builds a [TextSpan] based on [definitions].
+  ///
+  /// [oldBuilder] is used to decide whether to suppress unnecessary
+  /// text parsing and building of spans by comparing old and new
+  /// configurations. If not specified, every call to this method
+  /// newly parses text and builds spans.
+  Future<TextSpan> build({
+    required String text,
+    CustomSpanBuilder? oldBuilder,
+  }) async {
+    _parsed = false;
+    _built = false;
+    _text = text;
+    _span = oldBuilder?._span ?? const TextSpan();
+
+    final needsParse =
+        definitions.hasUpdatedMatchers(oldBuilder?.definitions) ||
+            parserOptions != oldBuilder?.parserOptions ||
+            text != oldBuilder?._text;
+
+    if (needsParse) {
+      _spansBuilder.elements = await _parse(text);
+      return _span = await _build(
+        currentSpans: _span.children ?? [],
+        updatedDefinitionIndexes: [],
+      );
+    }
+
+    final updatedDefIndexes =
+        definitions.findUpdatedDefinitions(oldBuilder?.definitions);
+
+    final needsBuild = updatedDefIndexes.isNotEmpty ||
+        style != oldBuilder?.style ||
+        matchStyle != oldBuilder?.matchStyle;
+
+    if (needsBuild) {
+      _spansBuilder.elements = oldBuilder?._spansBuilder.elements ?? [];
+      return _span = await _build(
+        currentSpans: _span.children ?? [],
+        updatedDefinitionIndexes: updatedDefIndexes,
+      );
+    }
+
+    return _span;
+  }
+
+  Future<List<TextElement>> _parse(String text) async {
+    final externalParser = parserOptions.parser;
+
+    final elements = externalParser == null
+        ? await TextParser(
+            matchers: definitions.map((def) => def.matcher),
+            multiLine: parserOptions.multiLine,
+            caseSensitive: parserOptions.caseSensitive,
+            unicode: parserOptions.unicode,
+            dotAll: parserOptions.dotAll,
+          ).parse(
+            text,
+            useIsolate: preventBlocking,
+          )
+        : await externalParser(text);
+
+    _parsed = true;
+
+    return elements;
+  }
+
+  Future<TextSpan> _build({
+    required List<InlineSpan> currentSpans,
+    required List<int> updatedDefinitionIndexes,
+  }) async {
+    final spans = _spansBuilder.elements.isEmpty
+        ? null
+        : _spansBuilder.buildSpans(
+            style: style,
+            currentSpans: currentSpans,
+            updatedDefinitionIndexes: updatedDefinitionIndexes,
+          );
+
+    _built = true;
+
+    return TextSpan(children: spans);
+  }
+}

--- a/lib/src/text_span/span_utils.dart
+++ b/lib/src/text_span/span_utils.dart
@@ -2,8 +2,8 @@ import 'package:flutter/gestures.dart' show TapGestureRecognizer;
 import 'package:flutter/widgets.dart';
 
 extension SpansToPlainText on List<InlineSpan>? {
-  String toPlainText() {
-    return TextSpan(children: this).toPlainText();
+  String? toPlainText() {
+    return this == null ? null : TextSpan(children: this).toPlainText();
   }
 }
 

--- a/test/unit_tests/custom_span_builder_test.dart
+++ b/test/unit_tests/custom_span_builder_test.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:custom_text/custom_text.dart';
+
+void main() {
+  group('CustomSpanBuilder', () {
+    test('Styles are applied as specified', () async {
+      const style = TextStyle(color: Color(0x11111111));
+      const matchStyle = TextStyle(color: Color(0x22222222));
+
+      final builder = CustomSpanBuilder(
+        definitions: [
+          const TextDefinition(
+            matcher: PatternMatcher('bbb'),
+            matchStyle: matchStyle,
+          ),
+        ],
+        style: style,
+      );
+      final builtSpan = await builder.build(text: 'aaabbbccc');
+
+      expect(
+        builtSpan.children,
+        const [
+          TextSpan(text: 'aaa', style: style),
+          TextSpan(text: 'bbb', style: matchStyle),
+          TextSpan(text: 'ccc', style: style),
+        ],
+      );
+    });
+
+    test('Builder also works with ParserOptions.external', () async {
+      const style = TextStyle(color: Color(0x11111111));
+      const matchStyle = TextStyle(color: Color(0x22222222));
+
+      final builder = CustomSpanBuilder(
+        style: style,
+        definitions: const [
+          TextDefinition(
+            matcher: PatternMatcher(''),
+            matchStyle: matchStyle,
+          ),
+        ],
+        parserOptions: ParserOptions.external((text) async {
+          return const [
+            TextElement('aaa'),
+            TextElement('bbb', matcherType: PatternMatcher),
+            TextElement('ccc'),
+          ];
+        }),
+      );
+      final builtSpan = await builder.build(text: 'aaabbbccc');
+
+      expect(
+        builtSpan.children,
+        const [
+          TextSpan(text: 'aaa', style: style),
+          TextSpan(text: 'bbb', style: matchStyle),
+          TextSpan(text: 'ccc', style: style),
+        ],
+      );
+    });
+
+    test(
+      'Arguments other than style, matchStyle, mouseCursor in definition '
+      'are ignored (cf. mouseCursor is also not used if builder is used '
+      'with CustomText)',
+      () async {
+        const style = TextStyle(color: Color(0x11111111));
+        const matchStyle = TextStyle(color: Color(0x22222222));
+        const tapStyle = TextStyle(color: Color(0x33333333));
+        const hoverStyle = TextStyle(color: Color(0x44444444));
+
+        final builder = CustomSpanBuilder(
+          definitions: [
+            TextDefinition(
+              matcher: const PatternMatcher('bbb'),
+              matchStyle: matchStyle,
+              mouseCursor: SystemMouseCursors.help,
+              tapStyle: tapStyle,
+              hoverStyle: hoverStyle,
+              onTap: (_) {},
+              onLongPress: (_) {},
+              onGesture: (_) {},
+            ),
+          ],
+          style: style,
+        );
+        final builtSpan = await builder.build(text: 'aaabbbccc');
+
+        expect(
+          builtSpan.children,
+          const [
+            TextSpan(text: 'aaa', style: style),
+            TextSpan(
+              text: 'bbb',
+              style: matchStyle,
+              mouseCursor: SystemMouseCursors.help,
+            ),
+            TextSpan(text: 'ccc', style: style),
+          ],
+        );
+      },
+    );
+
+    test('New builder with same config reuses the existing span', () async {
+      const definition = TextDefinition(matcher: PatternMatcher('bbb'));
+
+      final builder1 = CustomSpanBuilder(definitions: [definition]);
+      final builtSpan1 = await builder1.build(text: 'aaabbbccc');
+
+      expect(builder1.parsed, isTrue);
+      expect(builder1.built, isTrue);
+
+      final builder2 = CustomSpanBuilder(definitions: [definition]);
+      final builtSpan2 =
+          await builder2.build(text: 'aaabbbccc', oldBuilder: builder1);
+
+      expect(builder2.parsed, isFalse);
+      expect(builder2.built, isFalse);
+      expect(builtSpan2, same(builtSpan1));
+    });
+
+    test('Changing text causes text parsing', () async {
+      const definition = TextDefinition(matcher: PatternMatcher('bbb'));
+
+      final builder1 = CustomSpanBuilder(definitions: [definition]);
+      await builder1.build(text: 'aaabbbccc');
+
+      expect(builder1.parsed, isTrue);
+      expect(builder1.built, isTrue);
+
+      final builder2 = CustomSpanBuilder(definitions: [definition]);
+      await builder2.build(text: 'aaabbbddd', oldBuilder: builder1);
+
+      expect(builder2.parsed, isTrue);
+      expect(builder2.built, isTrue);
+    });
+
+    test('Changing pattern causes text parsing', () async {
+      final builder1 = CustomSpanBuilder(
+        definitions: const [
+          TextDefinition(matcher: PatternMatcher('bbb')),
+        ],
+      );
+      await builder1.build(text: 'aaabbbccc');
+
+      expect(builder1.parsed, isTrue);
+      expect(builder1.built, isTrue);
+
+      final builder2 = CustomSpanBuilder(
+        definitions: const [
+          TextDefinition(matcher: PatternMatcher('ccc')),
+        ],
+      );
+      await builder2.build(text: 'aaabbbccc', oldBuilder: builder1);
+
+      expect(builder2.parsed, isTrue);
+      expect(builder2.built, isTrue);
+    });
+
+    test('Changing parserOptions causes text parsing', () async {
+      const definition = TextDefinition(matcher: PatternMatcher('bbb'));
+
+      final builder1 = CustomSpanBuilder(
+        // ignore: avoid_redundant_argument_values
+        parserOptions: const ParserOptions(caseSensitive: true),
+        definitions: [definition],
+      );
+      await builder1.build(text: 'aaabbbccc');
+
+      expect(builder1.parsed, isTrue);
+      expect(builder1.built, isTrue);
+
+      final builder2 = CustomSpanBuilder(
+        parserOptions: const ParserOptions(caseSensitive: false),
+        definitions: [definition],
+      );
+      await builder2.build(text: 'aaabbbccc', oldBuilder: builder1);
+
+      expect(builder2.parsed, isTrue);
+      expect(builder2.built, isTrue);
+    });
+
+    test(
+      'Changing style or matchStyle causes a rebuild without text parsing',
+      () async {
+        final builder1 = CustomSpanBuilder(
+          definitions: const [
+            TextDefinition(matcher: PatternMatcher('bbb')),
+          ],
+          style: const TextStyle(color: Color(0x11111111)),
+        );
+        await builder1.build(text: 'aaabbbccc');
+
+        expect(builder1.parsed, isTrue);
+        expect(builder1.built, isTrue);
+
+        final builder2 = CustomSpanBuilder(
+          definitions: const [
+            TextDefinition(matcher: PatternMatcher('bbb')),
+          ],
+          style: const TextStyle(color: Color(0x22222222)),
+        );
+        await builder2.build(text: 'aaabbbccc', oldBuilder: builder1);
+
+        expect(builder2.parsed, isFalse);
+        expect(builder2.built, isTrue);
+
+        final builder3 = CustomSpanBuilder(
+          definitions: const [
+            TextDefinition(
+              matcher: PatternMatcher('bbb'),
+              matchStyle: TextStyle(color: Color(0x33333333)),
+            ),
+          ],
+          style: const TextStyle(color: Color(0x22222222)),
+        );
+        await builder3.build(text: 'aaabbbccc', oldBuilder: builder2);
+
+        expect(builder2.parsed, isFalse);
+        expect(builder2.built, isTrue);
+      },
+    );
+
+    test('preventBlocking does not affect the resulting span', () async {
+      const definition = TextDefinition(
+        matcher: PatternMatcher('bbb'),
+        matchStyle: TextStyle(color: Color(0x11111111)),
+      );
+
+      final builder1 = CustomSpanBuilder(
+        definitions: [definition],
+        // ignore: avoid_redundant_argument_values
+        preventBlocking: false,
+      );
+      final builtSpan1 = await builder1.build(text: 'aaabbbccc');
+
+      final builder2 = CustomSpanBuilder(
+        definitions: [definition],
+        preventBlocking: true,
+      );
+      final builtSpan2 = await builder2.build(text: 'aaabbbccc');
+
+      expect(builtSpan2, isNotNull);
+      expect(builtSpan2, builtSpan1);
+    });
+  });
+}

--- a/test/widget_tests/pre_builder_test.dart
+++ b/test/widget_tests/pre_builder_test.dart
@@ -1,0 +1,492 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:custom_text/custom_text.dart';
+
+import 'utils.dart';
+
+void main() {
+  var isParsedEntirely = false;
+
+  final externalParser = ParserOptions.external((text) async {
+    isParsedEntirely = true;
+    return const [
+      TextElement('aaa', matcherType: PatternMatcher),
+      TextElement('bbb'),
+    ];
+  });
+
+  tearDown(() => isParsedEntirely = false);
+
+  group('Composition', () {
+    testWidgets('Spans are built by builder', (tester) async {
+      const style = TextStyle(color: Color(0x11111111));
+      const matchStyle = TextStyle(color: Color(0x22222222));
+
+      await tester.pumpWidget(
+        CustomText(
+          'aaabbbccc',
+          textDirection: TextDirection.ltr,
+          definitions: const [
+            TextDefinition(matcher: PatternMatcher('')),
+          ],
+          preBuilder: CustomSpanBuilder(
+            definitions: const [
+              TextDefinition(
+                matcher: PatternMatcher('bbb'),
+                matchStyle: matchStyle,
+              ),
+            ],
+            style: style,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        findFirstTextSpan(),
+        const TextSpan(
+          children: [
+            TextSpan(
+              children: [
+                TextSpan(text: 'aaa', style: style),
+                TextSpan(text: 'bbb', style: matchStyle),
+                TextSpan(text: 'ccc', style: style),
+              ],
+            ),
+          ],
+        ),
+      );
+    });
+
+    testWidgets(
+      'CustomText parses children of TextSpan built by builder',
+      (tester) async {
+        const style = TextStyle(color: Color(0x11111111));
+        const matchStyle1 = TextStyle(decoration: TextDecoration.underline);
+        const matchStyle2 = TextStyle(color: Color(0x22222222));
+
+        await tester.pumpWidget(
+          CustomText(
+            'aaabbbccc',
+            textDirection: TextDirection.ltr,
+            definitions: const [
+              TextDefinition(
+                matcher: PatternMatcher('abbbc'),
+                matchStyle: matchStyle1,
+              ),
+            ],
+            preBuilder: CustomSpanBuilder(
+              definitions: const [
+                TextDefinition(
+                  matcher: PatternMatcher('bbb'),
+                  matchStyle: matchStyle2,
+                ),
+              ],
+              style: style,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          findFirstTextSpan(),
+          const TextSpan(
+            children: [
+              TextSpan(
+                children: [
+                  TextSpan(text: 'aa', style: style),
+                ],
+              ),
+              TextSpan(
+                style: matchStyle1,
+                children: [
+                  TextSpan(text: 'a', style: style),
+                  TextSpan(text: 'bbb', style: matchStyle2),
+                  TextSpan(text: 'c', style: style),
+                ],
+              ),
+              TextSpan(
+                children: [
+                  TextSpan(text: 'cc', style: style),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    testWidgets(
+      'Arguments other than style and matchStyle in definition are ignored '
+      '(cf. mouseCursor is used when builder is used independently)',
+      (tester) async {
+        const style = TextStyle(color: Color(0x11111111));
+        const matchStyle = TextStyle(color: Color(0x22222222));
+        const tapStyle = TextStyle(color: Color(0x33333333));
+        const hoverStyle = TextStyle(color: Color(0x44444444));
+
+        await tester.pumpWidget(
+          CustomText(
+            'aaabbbccc',
+            textDirection: TextDirection.ltr,
+            definitions: const [
+              TextDefinition(matcher: PatternMatcher('')),
+            ],
+            preBuilder: CustomSpanBuilder(
+              definitions: [
+                TextDefinition(
+                  matcher: const PatternMatcher('bbb'),
+                  matchStyle: matchStyle,
+                  mouseCursor: SystemMouseCursors.help,
+                  tapStyle: tapStyle,
+                  hoverStyle: hoverStyle,
+                  onTap: (_) {},
+                  onLongPress: (_) {},
+                  onGesture: (_) {},
+                ),
+              ],
+              style: style,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          findFirstTextSpan(),
+          const TextSpan(
+            children: [
+              TextSpan(
+                children: [
+                  TextSpan(text: 'aaa', style: style),
+                  TextSpan(text: 'bbb', style: matchStyle),
+                  TextSpan(text: 'ccc', style: style),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  });
+
+  group('Optimisation', () {
+    testWidgets(
+      'Rebuilding widget with same builder config does not rebuild spans',
+      (tester) async {
+        late CustomSpanBuilder builder;
+        var isWidgetBuilt = false;
+
+        await tester.pumpWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              isWidgetBuilt = true;
+
+              return Directionality(
+                textDirection: TextDirection.ltr,
+                child: Column(
+                  children: [
+                    CustomText(
+                      'aaabbb',
+                      parserOptions: externalParser,
+                      definitions: const [
+                        TextDefinition(matcher: PatternMatcher('')),
+                      ],
+                      preBuilder: builder = CustomSpanBuilder(
+                        definitions: const [
+                          TextDefinition(matcher: PatternMatcher('aaa')),
+                        ],
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => setState(() {}),
+                      child: const Text('Button'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+        await tester.pump();
+
+        final span1 = findFirstTextSpan();
+
+        isWidgetBuilt = false;
+        isParsedEntirely = false;
+        await tester.tapButton();
+        await tester.pumpAndSettle();
+
+        final span2 = findFirstTextSpan();
+        expect(isWidgetBuilt, isTrue);
+        expect(builder.parsed, isFalse);
+        expect(isParsedEntirely, isFalse);
+        expect(builder.built, isFalse);
+        expect(span2, same(span1));
+      },
+    );
+
+    testWidgets(
+      'Changing text causes parsing of text and rebuild of spans in both '
+      'builder and CustomText',
+      (tester) async {
+        late CustomSpanBuilder builder;
+        var text = 'aaabbb';
+
+        await tester.pumpWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return Directionality(
+                textDirection: TextDirection.ltr,
+                child: Column(
+                  children: [
+                    CustomText(
+                      text,
+                      parserOptions: externalParser,
+                      definitions: const [
+                        TextDefinition(matcher: PatternMatcher('')),
+                      ],
+                      preBuilder: builder = CustomSpanBuilder(
+                        definitions: const [
+                          TextDefinition(matcher: PatternMatcher('aaa')),
+                        ],
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => setState(() => text = 'aaaccc'),
+                      child: const Text('Button'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+        await tester.pump();
+
+        final span1 = findFirstTextSpan();
+
+        isParsedEntirely = false;
+        await tester.tapButton();
+        await tester.pumpAndSettle();
+
+        final span2 = findFirstTextSpan();
+        expect(builder.parsed, isTrue);
+        expect(isParsedEntirely, isTrue);
+        expect(builder.built, isTrue);
+        expect(span2, isNot(same(span1)));
+      },
+    );
+
+    testWidgets(
+      'Change of text or definition that results in same plain text '
+      'causes parsing and rebuilding only in builder',
+      (tester) async {
+        late CustomSpanBuilder builder;
+        Definition definition = const TextDefinition(
+          matcher: PatternMatcher('aaa'),
+        );
+        var text = 'aaabbb';
+
+        await tester.pumpWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return Directionality(
+                textDirection: TextDirection.ltr,
+                child: Column(
+                  children: [
+                    CustomText(
+                      text,
+                      parserOptions: externalParser,
+                      definitions: const [
+                        TextDefinition(matcher: PatternMatcher('')),
+                      ],
+                      preBuilder: builder = CustomSpanBuilder(
+                        definitions: [definition],
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          text = '[aaa]()bbb';
+                          definition = SelectiveDefinition(
+                            matcher: const LinkMatcher(),
+                            shownText: (_) => 'aaa',
+                          );
+                        });
+                      },
+                      child: const Text('Button'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+        await tester.pump();
+
+        final span1 = findFirstTextSpan();
+
+        isParsedEntirely = false;
+        await tester.tapButton();
+        await tester.pumpAndSettle();
+
+        final span2 = findFirstTextSpan();
+        expect(builder.parsed, isTrue);
+        expect(isParsedEntirely, isFalse);
+        expect(builder.built, isTrue);
+        expect(span2, same(span1));
+      },
+    );
+
+    testWidgets(
+      'Change of particular definition causes builder to rebuild only '
+      'relevant spans, but then triggers CustomText to rebuild entire spans',
+      (tester) async {
+        late CustomSpanBuilder builder;
+        var definitions = const [
+          TextDefinition(
+            matcher: PatternMatcher('bbb'),
+            matchStyle: TextStyle(color: Color(0x11111111)),
+          ),
+          TextDefinition(
+            matcher: PatternMatcher('ccc'),
+            matchStyle: TextStyle(color: Color(0x22222222)),
+          ),
+        ];
+        var parsedEntirely = false;
+
+        await tester.pumpWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return Directionality(
+                textDirection: TextDirection.ltr,
+                child: Column(
+                  children: [
+                    CustomText(
+                      'aaabbbccc',
+                      parserOptions: ParserOptions.external((text) async {
+                        parsedEntirely = true;
+                        return const [
+                          TextElement('aaa'),
+                          TextElement(
+                            'bbb',
+                            matcherType: PatternMatcher,
+                            matcherIndex: 1,
+                          ),
+                          TextElement(
+                            'ccc',
+                            matcherType: PatternMatcher,
+                            matcherIndex: 2,
+                          ),
+                        ];
+                      }),
+                      definitions: const [
+                        TextDefinition(matcher: PatternMatcher('')),
+                      ],
+                      preBuilder: builder = CustomSpanBuilder(
+                        definitions: definitions,
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          definitions = List.of(definitions)
+                            ..[0] = const TextDefinition(
+                              matcher: PatternMatcher('bbb'),
+                              matchStyle: TextStyle(color: Color(0x33333333)),
+                            );
+                        });
+                      },
+                      child: const Text('Button'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+        await tester.pump();
+
+        final spansByBuilder1 = builder.span.children!;
+        final span1a = findTextSpanByText('aaa');
+        final span1b = findTextSpanByText('bbb');
+        final span1c = findTextSpanByText('ccc');
+
+        parsedEntirely = false;
+        await tester.tapButton();
+        await tester.pumpAndSettle();
+
+        final spansByBuilder2 = builder.span.children!;
+        final span2a = findTextSpanByText('aaa');
+        final span2b = findTextSpanByText('bbb');
+        final span2c = findTextSpanByText('ccc');
+        expect(builder.parsed, isFalse);
+        expect(parsedEntirely, isFalse);
+        expect(builder.built, isTrue);
+        expect(spansByBuilder2[0], same(spansByBuilder1[0]));
+        expect(spansByBuilder2[1], isNot(same(spansByBuilder1[1])));
+        expect(spansByBuilder2[2], same(spansByBuilder1[2]));
+        expect(span2a, isNot(same(span1a)));
+        expect(span2b, isNot(same(span1b)));
+        expect(span2c, isNot(same(span1c)));
+      },
+    );
+
+    testWidgets(
+      'Change of callbacks do not cause parsing of text nor rebuild of spans',
+      (tester) async {
+        late CustomSpanBuilder builder;
+        var shownText = (_) => '111';
+
+        await tester.pumpWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              return Directionality(
+                textDirection: TextDirection.ltr,
+                child: Column(
+                  children: [
+                    CustomText(
+                      'aaabbb',
+                      parserOptions: externalParser,
+                      definitions: const [
+                        TextDefinition(matcher: PatternMatcher('')),
+                      ],
+                      preBuilder: builder = CustomSpanBuilder(
+                        definitions: [
+                          SelectiveDefinition(
+                            matcher: const PatternMatcher('aaa'),
+                            shownText: shownText,
+                          ),
+                        ],
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: () {
+                        setState(() => shownText = (_) => '222');
+                      },
+                      child: const Text('Button'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+        await tester.pump();
+
+        final span1 = findFirstTextSpan();
+
+        isParsedEntirely = false;
+        await tester.tapButton();
+        await tester.pumpAndSettle();
+
+        final span2 = findFirstTextSpan();
+        expect(builder.parsed, isFalse);
+        expect(isParsedEntirely, isFalse);
+        expect(builder.built, isFalse);
+        expect(span2, same(span1));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #41

- Add `CustomSpanBuilder`.
- Add the `preBuilder` parameter to CustomText.

`CustomSpanBuilder` is basically used for `preBuilder` of CustomText. It can also be used independently to build a `TextSpan`. It has been designed so that it can be used similarly to CustomText. However, there is a big difference that the builder ignores gesture actions specified in definitions.