### PR TITLE
Add `rebuildKey` to definitions

### DIFF
--- a/lib/src/definition_base.dart
+++ b/lib/src/definition_base.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show Key;
 import 'package:flutter/painting.dart' show InlineSpan, TextStyle;
 import 'package:flutter/services.dart' show MouseCursor;
 
@@ -30,6 +31,7 @@ abstract class Definition {
   // ignore: public_member_api_docs
   const Definition({
     required this.matcher,
+    this.rebuildKey,
     this.shownText,
     this.actionText,
     this.builder,
@@ -44,6 +46,15 @@ abstract class Definition {
 
   /// The matcher used to parse text for this definition.
   final TextMatcher matcher;
+
+  /// A key that is used to decide whether to rebuild the [InlineSpan]s
+  /// relevant to this definition.
+  ///
+  /// [CustomText] rebuilds [InlineSpan]s when configurations in definitions
+  /// are updated, but changes in callbacks do not trigger rebuilds because
+  /// CustomText cannot evaluate the differences of callbacks.
+  /// In such cases, it is possible to cause a rebuild by changing this key.
+  final Key? rebuildKey;
 
   /// The function to choose a string to be shown.
   final ShownTextSelector? shownText;
@@ -86,6 +97,7 @@ abstract class Definition {
       other is Definition &&
           runtimeType == other.runtimeType &&
           matcher == other.matcher &&
+          rebuildKey == other.rebuildKey &&
           matchStyle == other.matchStyle &&
           tapStyle == other.tapStyle &&
           hoverStyle == other.hoverStyle &&
@@ -95,6 +107,7 @@ abstract class Definition {
   int get hashCode => Object.hash(
         runtimeType,
         matcher,
+        rebuildKey,
         matchStyle,
         tapStyle,
         hoverStyle,

--- a/lib/src/definitions.dart
+++ b/lib/src/definitions.dart
@@ -38,6 +38,7 @@ class TextDefinition extends Definition {
   /// {@macro customText.textDefinition}
   const TextDefinition({
     required super.matcher,
+    super.rebuildKey,
     super.matchStyle,
     super.tapStyle,
     super.hoverStyle,
@@ -80,6 +81,7 @@ class SelectiveDefinition extends Definition {
   const SelectiveDefinition({
     required super.matcher,
     required ShownTextSelector super.shownText,
+    super.rebuildKey,
     super.actionText,
     super.matchStyle,
     super.tapStyle,
@@ -120,6 +122,7 @@ class SpanDefinition extends Definition {
   const SpanDefinition({
     required super.matcher,
     required SpanBuilder super.builder,
+    super.rebuildKey,
     super.matchStyle,
     super.tapStyle,
     super.hoverStyle,

--- a/lib/src/text.dart
+++ b/lib/src/text.dart
@@ -457,9 +457,11 @@ class _CustomTextState extends State<CustomText> {
       // it is the time to show it, except in some cases where
       // it should be hidden until parsing completes.
       if (!hasElements && hasText && !_shouldBeInvisibleDuringParsing()) {
-        _textSpanNotifier.value = TextSpan(
-          text: widget.text,
-          style: widget.style,
+        _textSpanNotifier.updateValue(
+          TextSpan(
+            text: widget.text,
+            style: widget.style,
+          ),
         );
       }
     }

--- a/test/widget_tests/pre_builder_test.dart
+++ b/test/widget_tests/pre_builder_test.dart
@@ -280,7 +280,8 @@ void main() {
 
     testWidgets(
       'Change of text or definition that results in same plain text '
-      'causes parsing and rebuilding only in builder',
+      'causes parsing only in builder, but then also triggers CustomText '
+      'to rebuild entire span',
       (tester) async {
         late CustomSpanBuilder builder;
         Definition definition = const TextDefinition(
@@ -335,7 +336,7 @@ void main() {
         expect(builder.parsed, isTrue);
         expect(isParsedEntirely, isFalse);
         expect(builder.built, isTrue);
-        expect(span2, same(span1));
+        expect(span2, isNot(same(span1)));
       },
     );
 

--- a/test/widget_tests/rebuild_key_test.dart
+++ b/test/widget_tests/rebuild_key_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:custom_text/custom_text.dart';
+
+import 'utils.dart';
+import 'widgets.dart';
+
+void main() {
+  testWidgets(
+    'Changing rebuildKey causes a rebuild of only relevant spans',
+    (tester) async {
+      var rebuildKey = const ValueKey(1);
+
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (_, setState) {
+            return CustomTextWidget(
+              'aaabbbccc',
+              definitions: [
+                TextDefinition(
+                  rebuildKey: rebuildKey,
+                  matcher: const PatternMatcher('bbb'),
+                ),
+                const TextDefinition(
+                  matcher: PatternMatcher('ccc'),
+                ),
+              ],
+              onButtonPressed: () {
+                setState(() => rebuildKey = const ValueKey(2));
+              },
+            );
+          },
+        ),
+      );
+      await tester.pump();
+
+      final spans1 = List.of(findFirstTextSpan()!.children!);
+
+      await tester.tapButton();
+      await tester.pumpAndSettle();
+
+      final spans2 = List.of(findFirstTextSpan()!.children!);
+
+      expect(spans1, hasLength(3));
+      expect(spans2, hasLength(3));
+
+      expect(spans2[0], same(spans1[0]));
+      expect(spans2[1], isNot(same(spans1[1])));
+      expect(spans2[2], same(spans1[2]));
+    },
+  );
+
+  testWidgets(
+    'Changing rebuildKey in preBuilder causes a rebuild in CustomSpan too '
+    'despite no actual change in spans built in preBuilder',
+    (tester) async {
+      late CustomSpanBuilder builder;
+      var rebuildKey = const ValueKey(1);
+      var parsedEntirely = false;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: StatefulBuilder(
+            builder: (context, setState) {
+              return Column(
+                children: [
+                  CustomText(
+                    'aaabbbccc',
+                    definitions: const [
+                      TextDefinition(matcher: PatternMatcher('')),
+                    ],
+                    preBuilder: builder = CustomSpanBuilder(
+                      definitions: [
+                        TextDefinition(
+                          rebuildKey: rebuildKey,
+                          matcher: const PatternMatcher('bbb'),
+                        ),
+                        const TextDefinition(
+                          matcher: PatternMatcher('ccc'),
+                        ),
+                      ],
+                    ),
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      setState(() => rebuildKey = const ValueKey(2));
+                    },
+                    child: const Text('Button'),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final spansByBuilder1 = builder.span.children!;
+      final span1 = findFirstTextSpan();
+
+      parsedEntirely = false;
+      await tester.tapButton();
+      await tester.pumpAndSettle();
+
+      final spansByBuilder2 = builder.span.children!;
+      final span2 = findFirstTextSpan();
+
+      expect(builder.parsed, isFalse);
+      expect(parsedEntirely, isFalse);
+      expect(builder.built, isTrue);
+      expect(spansByBuilder2[0], same(spansByBuilder1[0]));
+      expect(spansByBuilder2[1], isNot(same(spansByBuilder1[1])));
+      expect(spansByBuilder2[2], same(spansByBuilder1[2]));
+      expect(span2, isNot(same(span1)));
+    },
+  );
+}


### PR DESCRIPTION
Closes #40.

It was necessary to replace `ValueNotifier` used in internal CustomTextSpanNotifier with a custom one to achieve this feature. `ValueNotifier` avoids reassigning a new value to `value` if it is evaluated as equal to the previous value by the `==` operator , but comparison of `InlineSpan`'s subtypes using `==` does not go well with the mechanism. For example, the child of `WidgetSpan` has changed but the instance has not changed, `==` returns `true`. It means that a rebuilt span can be considered unchanged and not assigned to `value`. It might have been a potential issue that should be fixed regardless of this `rebuildKey` feature.