### PR TITLE
Fix wrong handling of styles in CustomTextEditingController

### DIFF
--- a/test/widget_tests/text_editing_controller_test.dart
+++ b/test/widget_tests/text_editing_controller_test.dart
@@ -2,7 +2,7 @@ import 'dart:async' show Completer;
 
 import 'package:flutter/material.dart' show Material, Theme;
 import 'package:flutter/painting.dart';
-import 'package:flutter/widgets.dart' show Builder;
+import 'package:flutter/widgets.dart' show Builder, StatefulBuilder;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:custom_text/custom_text.dart';
@@ -81,6 +81,84 @@ void main() {
             ],
           ),
         );
+      },
+    );
+
+    testWidgets(
+      'Cursor respects text height specified in style of editable text',
+      (tester) async {
+        final controller = CustomTextEditingController(
+          text: 'abc',
+          definitions: const [
+            TextDefinition(matcher: PatternMatcher('')),
+          ],
+        );
+        addTearDown(controller.dispose);
+
+        late TextStyle bodyLarge;
+        await tester.pumpWidget(
+          Material(
+            child: Builder(
+              builder: (context) {
+                bodyLarge = Theme.of(context).textTheme.bodyLarge!;
+                return TextFieldWidget(
+                  controller: controller,
+                  style: const TextStyle(height: 2.0),
+                );
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final rect = tester.getCursorRect();
+        expect(rect.height, bodyLarge.fontSize! * 2.0);
+      },
+    );
+
+    testWidgets(
+      'Changes in style specified in editable text are applied quickly',
+      (tester) async {
+        final controller = CustomTextEditingController(
+          text: 'abc',
+          definitions: const [
+            TextDefinition(matcher: PatternMatcher('')),
+          ],
+        );
+        addTearDown(controller.dispose);
+
+        var style = const TextStyle();
+        const style2 = TextStyle(height: 1.8, fontSize: 30.0);
+
+        late TextStyle bodyLarge;
+        await tester.pumpWidget(
+          Material(
+            child: StatefulBuilder(
+              builder: (context, setState) {
+                bodyLarge = Theme.of(context).textTheme.bodyLarge!;
+                return TextFieldWidget(
+                  controller: controller,
+                  style: style,
+                  onButtonPressed: () => setState(() => style = style2),
+                );
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final textHeight1 = tester.findRenderEditable()!.size.height;
+        final cursorHeight1 = tester.getCursorRect().height;
+        expect(textHeight1, bodyLarge.fontSize! * bodyLarge.height!);
+        expect(cursorHeight1, textHeight1);
+
+        await tester.tapButton();
+        await tester.pump();
+
+        final textHeight2 = tester.findRenderEditable()!.size.height;
+        final cursorHeight2 = tester.getCursorRect().height;
+        expect(textHeight2, style2.fontSize! * style2.height!);
+        expect(cursorHeight2, textHeight2);
       },
     );
   });

--- a/test/widget_tests/utils.dart
+++ b/test/widget_tests/utils.dart
@@ -128,4 +128,9 @@ extension WidgetTesterExtension on WidgetTester {
 
     return renderEditable;
   }
+
+  Rect getCursorRect() {
+    return findRenderEditable()!
+        .getLocalRectForCaret(const TextPosition(offset: 0));
+  }
 }

--- a/test/widget_tests/widgets.dart
+++ b/test/widget_tests/widgets.dart
@@ -98,18 +98,28 @@ class TextFieldWidget extends StatelessWidget {
     super.key,
     required this.controller,
     this.style,
+    this.onButtonPressed,
   });
 
   final CustomTextEditingController controller;
   final TextStyle? style;
+  final VoidCallback? onButtonPressed;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        body: TextField(
-          controller: controller,
-          style: style,
+        body: Column(
+          children: [
+            TextField(
+              controller: controller,
+              style: style,
+            ),
+            ElevatedButton(
+              onPressed: onButtonPressed,
+              child: const Text('Button'),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Fixes #60.

This fixes the following bugs:

- The cursor didn't match text height.
- The style specified in editable text was ignored if another style is passed to the controller.
- A change in the style specified in editable text was not applied until text was updated.
